### PR TITLE
1.17.x maintenance

### DIFF
--- a/1.17-aarch64/1.17-aarch64.json
+++ b/1.17-aarch64/1.17-aarch64.json
@@ -472,13 +472,13 @@
         {
             "downloads": {
                 "artifact": {
-                    "path": "org/lwjgl/lwjgl/3.3.0-SNAPSHOT/lwjgl-3.3.0-SNAPSHOT.jar",
-                    "sha1": "58af756828308c0e6a2e481457de166a3d126c5a",
-                    "size": 567426,
-                    "url": "https://oss.sonatype.org/service/local/repositories/snapshots/content/org/lwjgl/lwjgl/3.3.0-SNAPSHOT/lwjgl-3.3.0-20210325.222416-6.jar"
+                    "path": "org/lwjgl/lwjgl/3.3.0/lwjgl-3.3.0.jar",
+                    "sha1": "77b0dc0b6a6c82fb47368e73d55e23fdcfcf49a1",
+                    "size": 555380,
+                    "url": "https://oss.sonatype.org/service/local/repositories/releases/content/org/lwjgl/lwjgl/3.3.0/lwjgl-3.3.0.jar"
                 }
             },
-            "name": "org.lwjgl:lwjgl:3.3.0-SNAPSHOT",
+            "name": "org.lwjgl:lwjgl:3.3.0",
             "rules": [
                 {
                     "action": "allow"
@@ -513,13 +513,13 @@
         {
             "downloads": {
                 "artifact": {
-                    "path": "org/lwjgl/lwjgl-jemalloc/3.3.0-SNAPSHOT/lwjgl-jemalloc-3.3.0-SNAPSHOT.jar",
-                    "sha1": "8b756cd284b4f7ba9706069725b90ad393a65599",
-                    "size": 36676,
-                    "url": "https://oss.sonatype.org/service/local/repositories/snapshots/content/org/lwjgl/lwjgl-jemalloc/3.3.0-SNAPSHOT/lwjgl-jemalloc-3.3.0-20210325.222416-6.jar"
+                    "path": "/org/lwjgl/lwjgl-jemalloc/3.3.0/lwjgl-jemalloc-3.3.0.jar",
+                    "sha1": "ce52faa3fd0c9ed7af45145e94b01eade5fd5daf",
+                    "size": 35740,
+                    "url": "https://oss.sonatype.org/service/local/repositories/releases/content/org/lwjgl/lwjgl-jemalloc/3.3.0/lwjgl-jemalloc-3.3.0.jar"
                 }
             },
-            "name": "org.lwjgl:lwjgl-jemalloc:3.3.0-SNAPSHOT",
+            "name": "org.lwjgl:lwjgl-jemalloc:3.3.0",
             "rules": [
                 {
                     "action": "allow"
@@ -554,13 +554,13 @@
         {
             "downloads": {
                 "artifact": {
-                    "path": "org/lwjgl/lwjgl-openal/3.3.0-SNAPSHOT/lwjgl-openal-3.3.0-SNAPSHOT.jar",
-                    "sha1": "6e8e9d7ae6d64c96f35618354401788a848d9748",
-                    "size": 88053,
-                    "url": "https://oss.sonatype.org/service/local/repositories/snapshots/content/org/lwjgl/lwjgl-openal/3.3.0-SNAPSHOT/lwjgl-openal-3.3.0-20210325.222416-6.jar"
+                    "path": "org/lwjgl/lwjgl-openal/3.3.0/lwjgl-openal-3.3.0.jar",
+                    "sha1": "902dd57b5a46e8a75ee843c2db61f80b4d130d48",
+                    "size": 86170,
+                    "url": "https://oss.sonatype.org/service/local/repositories/releases/content/org/lwjgl/lwjgl-openal/3.3.0/lwjgl-openal-3.3.0.jar"
                 }
             },
-            "name": "org.lwjgl:lwjgl-openal:3.3.0-SNAPSHOT",
+            "name": "org.lwjgl:lwjgl-openal:3.3.0",
             "rules": [
                 {
                     "action": "allow"
@@ -595,13 +595,13 @@
         {
             "downloads": {
                 "artifact": {
-                    "path": "org/lwjgl/lwjgl-opengl/3.3.0-SNAPSHOT/lwjgl-opengl-3.3.0-SNAPSHOT.jar",
-                    "sha1": "3aed63a7a8e158fd3e9d3e0a17358f38fe506a8c",
-                    "size": 916567,
-                    "url": "https://oss.sonatype.org/service/local/repositories/snapshots/content/org/lwjgl/lwjgl-opengl/3.3.0-SNAPSHOT/lwjgl-opengl-3.3.0-20210325.222416-6.jar"
+                    "path": "org/lwjgl/lwjgl-opengl/3.3.0/lwjgl-opengl-3.3.0.jar",
+                    "sha1": "a1f395f7758a3abd5aff75fc8a20368ac371631e",
+                    "size": 899820,
+                    "url": "https://oss.sonatype.org/service/local/repositories/releases/content/org/lwjgl/lwjgl-opengl/3.3.0/lwjgl-opengl-3.3.0.jar"
                 }
             },
-            "name": "org.lwjgl:lwjgl-opengl:3.3.0-SNAPSHOT",
+            "name": "org.lwjgl:lwjgl-opengl:3.3.0",
             "rules": [
                 {
                     "action": "allow"
@@ -636,13 +636,13 @@
         {
             "downloads": {
                 "artifact": {
-                    "path": "org/lwjgl/lwjgl-glfw/3.3.0-SNAPSHOT/lwjgl-glfw-3.3.0-SNAPSHOT.jar",
-                    "sha1": "0c41e6dff8c44fc7dcacda7c39c9297e7d100548",
-                    "size": 117915,
-                    "url": "https://oss.sonatype.org/service/local/repositories/snapshots/content/org/lwjgl/lwjgl-glfw/3.3.0-SNAPSHOT/lwjgl-glfw-3.3.0-20210325.222416-6.jar"
+                    "path": "org/lwjgl/lwjgl-glfw/3.3.0/lwjgl-glfw-3.3.0.jar",
+                    "sha1": "899e34f314525596f8fdb6476d3e56104da4601d",
+                    "size": 125600,
+                    "url": "https://oss.sonatype.org/service/local/repositories/releases/content/org/lwjgl/lwjgl-glfw/3.3.0/lwjgl-glfw-3.3.0.jar"
                 }
             },
-            "name": "org.lwjgl:lwjgl-glfw:3.3.0-SNAPSHOT",
+            "name": "org.lwjgl:lwjgl-glfw:3.3.0",
             "rules": [
                 {
                     "action": "allow"
@@ -677,13 +677,13 @@
         {
             "downloads": {
                 "artifact": {
-                    "path": "org/lwjgl/lwjgl-stb/3.3.0-SNAPSHOT/lwjgl-stb-3.3.0-SNAPSHOT.jar",
-                    "sha1": "e7a20f5ef01143f621131670c10cfee343968b82",
-                    "size": 111375,
-                    "url": "https://oss.sonatype.org/service/local/repositories/snapshots/content/org/lwjgl/lwjgl-stb/3.3.0-SNAPSHOT/lwjgl-stb-3.3.0-20210325.222416-6.jar"
+                    "path": "org/lwjgl/lwjgl-stb/3.3.0/lwjgl-stb-3.3.0.jar",
+                    "sha1": "69becce49e19671fccca33bfb273231055bd9fcf",
+                    "size": 109740,
+                    "url": "https://oss.sonatype.org/service/local/repositories/releases/content/org/lwjgl/lwjgl-stb/3.3.0/lwjgl-stb-3.3.0.jar"
                 }
             },
-            "name": "org.lwjgl:lwjgl-stb:3.3.0-SNAPSHOT",
+            "name": "org.lwjgl:lwjgl-stb:3.3.0",
             "rules": [
                 {
                     "action": "allow"
@@ -718,13 +718,13 @@
         {
             "downloads": {
                 "artifact": {
-                    "path": "org/lwjgl/lwjgl-tinyfd/3.3.0-SNAPSHOT/lwjgl-tinyfd-3.3.0-SNAPSHOT.jar",
-                    "sha1": "a6b8fb51fac7b53101fcc1dce380766d76635b33",
-                    "size": 6758,
-                    "url": "https://oss.sonatype.org/service/local/repositories/snapshots/content/org/lwjgl/lwjgl-tinyfd/3.3.0-SNAPSHOT/lwjgl-tinyfd-3.3.0-20210325.222416-6.jar"
+                    "path": "org/lwjgl/lwjgl-tinyfd/3.3.0/lwjgl-tinyfd-3.3.0.jar",
+                    "sha1": "e3bf58d4830e2b35ee7e6f40b1eafd8637c290b8",
+                    "size": 6610,
+                    "url": "https://oss.sonatype.org/service/local/repositories/releases/content/org/lwjgl/lwjgl-tinyfd/3.3.0/lwjgl-tinyfd-3.3.0.jar"
                 }
             },
-            "name": "org.lwjgl:lwjgl-tinyfd:3.3.0-SNAPSHOT",
+            "name": "org.lwjgl:lwjgl-tinyfd:3.3.0",
             "rules": [
                 {
                     "action": "allow"
@@ -794,10 +794,10 @@
         {
             "downloads": {
                 "artifact": {
-                    "path": "org/lwjgl/lwjgl/3.3.0-SNAPSHOT/lwjgl-3.3.0-SNAPSHOT.jar",
-                    "sha1": "58af756828308c0e6a2e481457de166a3d126c5a",
-                    "size": 567426,
-                    "url": "https://oss.sonatype.org/service/local/repositories/snapshots/content/org/lwjgl/lwjgl/3.3.0-SNAPSHOT/lwjgl-3.3.0-20210325.222416-6.jar"
+                    "path": "org/lwjgl/lwjgl/3.3.0/lwjgl-3.3.0.jar",
+                    "sha1": "77b0dc0b6a6c82fb47368e73d55e23fdcfcf49a1",
+                    "size": 555380,
+                    "url": "https://oss.sonatype.org/service/local/repositories/releases/content/org/lwjgl/lwjgl/3.3.0/lwjgl-3.3.0.jar"
                 },
                 "classifiers": {
                     "natives-linux": {
@@ -813,14 +813,14 @@
                         "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl/3.2.2/lwjgl-3.2.2-natives-macos.jar"
                     },
                     "natives-windows": {
-                        "path": "org/lwjgl/lwjgl/3.3.0-SNAPSHOT/lwjgl-3.3.0-SNAPSHOT-natives-windows.jar",
-                        "sha1": "c7a9cc3bc12bc06002e4a2efe0299c4236984409",
-                        "size": 123938,
-                        "url": "https://oss.sonatype.org/service/local/repositories/snapshots/content/org/lwjgl/lwjgl/3.3.0-SNAPSHOT/lwjgl-3.3.0-20210325.222416-6-natives-windows-arm64.jar"
+                        "path": "org/lwjgl/lwjgl/3.3.0/lwjgl-3.3.0-natives-windows.jar",
+                        "sha1": "a2a2ab21d619a4b08fdb52962761ccd822573908",
+                        "size": 124590,
+                        "url": "https://oss.sonatype.org/service/local/repositories/releases/content/org/lwjgl/lwjgl/3.3.0/lwjgl-3.3.0-natives-windows-arm64.jar"
                     }
                 }
             },
-            "name": "org.lwjgl:lwjgl:3.3.0-SNAPSHOT",
+            "name": "org.lwjgl:lwjgl:3.3.0",
             "natives": {
                 "linux": "natives-linux",
                 "windows": "natives-windows"
@@ -894,10 +894,10 @@
         {
             "downloads": {
                 "artifact": {
-                    "path": "org/lwjgl/lwjgl-jemalloc/3.3.0-SNAPSHOT/lwjgl-jemalloc-3.3.0-SNAPSHOT.jar",
-                    "sha1": "8b756cd284b4f7ba9706069725b90ad393a65599",
-                    "size": 36676,
-                    "url": "https://oss.sonatype.org/service/local/repositories/snapshots/content/org/lwjgl/lwjgl-jemalloc/3.3.0-SNAPSHOT/lwjgl-jemalloc-3.3.0-20210325.222416-6.jar"
+                    "path": "org/lwjgl/lwjgl-jemalloc/3.3.0/lwjgl-jemalloc-3.3.0.jar",
+                    "sha1": "ce52faa3fd0c9ed7af45145e94b01eade5fd5daf",
+                    "size": 35740,
+                    "url": "https://oss.sonatype.org/service/local/repositories/releases/content/org/lwjgl/lwjgl-jemalloc/3.3.0/lwjgl-jemalloc-3.3.0.jar"
                 },
                 "classifiers": {
                     "natives-linux": {
@@ -913,14 +913,14 @@
                         "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-jemalloc/3.2.2/lwjgl-jemalloc-3.2.2-natives-macos.jar"
                     },
                     "natives-windows": {
-                        "path": "org/lwjgl/lwjgl-jemalloc/3.3.0-SNAPSHOT/lwjgl-jemalloc-3.3.0-SNAPSHOT-natives-windows.jar",
-                        "sha1": "f8e04e4a3a2d887fe4052e27c8a2538abba370ae",
-                        "size": 107110,
-                        "url": "https://oss.sonatype.org/service/local/repositories/snapshots/content/org/lwjgl/lwjgl-jemalloc/3.3.0-SNAPSHOT/lwjgl-jemalloc-3.3.0-20210325.222416-6-natives-windows-arm64.jar"
+                        "path": "org/lwjgl/lwjgl-jemalloc/3.3.0/lwjgl-jemalloc-3.3.0-natives-windows.jar",
+                        "sha1": "fc4438bc0bd9535b3bb02aeae287a5cec3cf58dc",
+                        "size": 104470,
+                        "url": "https://oss.sonatype.org/service/local/repositories/releases/content/org/lwjgl/lwjgl-jemalloc/3.3.0/lwjgl-jemalloc-3.3.0-natives-windows-arm64.jar"
                     }
                 }
             },
-            "name": "org.lwjgl:lwjgl-jemalloc:3.3.0-SNAPSHOT",
+            "name": "org.lwjgl:lwjgl-jemalloc:3.3.0",
             "natives": {
                 "linux": "natives-linux",
                 "windows": "natives-windows"
@@ -994,10 +994,10 @@
         {
             "downloads": {
                 "artifact": {
-                    "path": "org/lwjgl/lwjgl-openal/3.3.0-SNAPSHOT/lwjgl-openal-3.3.0-SNAPSHOT.jar",
-                    "sha1": "6e8e9d7ae6d64c96f35618354401788a848d9748",
-                    "size": 88053,
-                    "url": "https://oss.sonatype.org/service/local/repositories/snapshots/content/org/lwjgl/lwjgl-openal/3.3.0-SNAPSHOT/lwjgl-openal-3.3.0-20210325.222416-6.jar"
+                    "path": "org/lwjgl/lwjgl-openal/3.3.0/lwjgl-openal-3.3.0.jar",
+                    "sha1": "902dd57b5a46e8a75ee843c2db61f80b4d130d48",
+                    "size": 56170,
+                    "url": "https://oss.sonatype.org/service/local/repositories/releases/content/org/lwjgl/lwjgl-openal/3.3.0/lwjgl-openal-3.3.0.jar"
                 },
                 "classifiers": {
                     "natives-linux": {
@@ -1013,14 +1013,14 @@
                         "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-openal/3.2.2/lwjgl-openal-3.2.2-natives-macos.jar"
                     },
                     "natives-windows": {
-                        "path": "org/lwjgl/lwjgl-openal/3.3.0-SNAPSHOT/lwjgl-openal-3.3.0-SNAPSHOT-natives-windows.jar",
-                        "sha1": "2b475d03d01adf84b75c914ffcf84a196214a091",
-                        "size": 503283,
-                        "url": "https://oss.sonatype.org/service/local/repositories/snapshots/content/org/lwjgl/lwjgl-openal/3.3.0-SNAPSHOT/lwjgl-openal-3.3.0-20210325.222416-6-natives-windows-arm64.jar"
+                        "path": "org/lwjgl/lwjgl-openal/3.3.0/lwjgl-openal-3.3.0-natives-windows.jar",
+                        "sha1": "c297c0db767a23af1ace227664ddd2887e900a43",
+                        "size": 493390,
+                        "url": "https://oss.sonatype.org/service/local/repositories/releases/content/org/lwjgl/lwjgl-openal/3.3.0/lwjgl-openal-3.3.0-natives-windows-arm64.jar"
                     }
                 }
             },
-            "name": "org.lwjgl:lwjgl-openal:3.3.0-SNAPSHOT",
+            "name": "org.lwjgl:lwjgl-openal:3.3.0",
             "natives": {
                 "linux": "natives-linux",
                 "windows": "natives-windows"
@@ -1094,10 +1094,10 @@
         {
             "downloads": {
                 "artifact": {
-                    "path": "org/lwjgl/lwjgl-opengl/3.3.0-SNAPSHOT/lwjgl-opengl-3.3.0-SNAPSHOT.jar",
-                    "sha1": "3aed63a7a8e158fd3e9d3e0a17358f38fe506a8c",
-                    "size": 916567,
-                    "url": "https://oss.sonatype.org/service/local/repositories/snapshots/content/org/lwjgl/lwjgl-opengl/3.3.0-SNAPSHOT/lwjgl-opengl-3.3.0-20210325.222416-6.jar"
+                    "path": "org/lwjgl/lwjgl-opengl/3.3.0/lwjgl-opengl-3.3.0.jar",
+                    "sha1": "a1f395f7758a3abd5aff75fc8a20368ac371631e",
+                    "size": 899820,
+                    "url": "https://oss.sonatype.org/service/local/repositories/releases/content/org/lwjgl/lwjgl-opengl/3.3.0/lwjgl-opengl-3.3.0.jar"
                 },
                 "classifiers": {
                     "natives-linux": {
@@ -1113,14 +1113,14 @@
                         "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-opengl/3.2.2/lwjgl-opengl-3.2.2-natives-macos.jar"
                     },
                     "natives-windows": {
-                        "path": "org/lwjgl/lwjgl-opengl/3.3.0-SNAPSHOT/lwjgl-opengl-3.3.0-SNAPSHOT-natives-windows.jar",
-                        "sha1": "69b52e6a28bfd10b13a358630e8c4662b9646c36",
-                        "size": 75496,
-                        "url": "https://oss.sonatype.org/service/local/repositories/snapshots/content/org/lwjgl/lwjgl-opengl/3.3.0-SNAPSHOT/lwjgl-opengl-3.3.0-20210325.222416-6-natives-windows-arm64.jar"
+                        "path": "org/lwjgl/lwjgl-opengl/3.3.0/lwjgl-opengl-3.3.0-natives-windows.jar",
+                        "sha1": "0b08e49c2ac976942b5fd6f146b790d0c0098c39",
+                        "size": 80280,
+                        "url": "https://oss.sonatype.org/service/local/repositories/releases/content/org/lwjgl/lwjgl-opengl/3.3.0/lwjgl-opengl-3.3.0-natives-windows-arm64.jar"
                     }
                 }
             },
-            "name": "org.lwjgl:lwjgl-opengl:3.3.0-SNAPSHOT",
+            "name": "org.lwjgl:lwjgl-opengl:3.3.0",
             "natives": {
                 "linux": "natives-linux",
                 "windows": "natives-windows"
@@ -1194,10 +1194,10 @@
         {
             "downloads": {
                 "artifact": {
-                    "path": "org/lwjgl/lwjgl-glfw/3.3.0-SNAPSHOT/lwjgl-glfw-3.3.0-SNAPSHOT.jar",
-                    "sha1": "0c41e6dff8c44fc7dcacda7c39c9297e7d100548",
-                    "size": 117915,
-                    "url": "https://oss.sonatype.org/service/local/repositories/snapshots/content/org/lwjgl/lwjgl-glfw/3.3.0-SNAPSHOT/lwjgl-glfw-3.3.0-20210325.222416-6.jar"
+                    "path": "org/lwjgl/lwjgl-glfw/3.3.0/lwjgl-glfw-3.3.0.jar",
+                    "sha1": "899e34f314525596f8fdb6476d3e56104da4601d",
+                    "size": 125600,
+                    "url": "https://oss.sonatype.org/service/local/repositories/releases/content/org/lwjgl/lwjgl-glfw/3.3.0/lwjgl-glfw-3.3.0.jar"
                 },
                 "classifiers": {
                     "natives-linux": {
@@ -1213,14 +1213,14 @@
                         "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-glfw/3.2.2/lwjgl-glfw-3.2.2-natives-macos.jar"
                     },
                     "natives-windows": {
-                        "path": "org/lwjgl/lwjgl-glfw/3.3.0-SNAPSHOT/lwjgl-glfw-3.3.0-SNAPSHOT-natives-windows.jar",
-                        "sha1": "9f3a847ca6d2f6f357fb8893a06cfd6de20ee74e",
-                        "size": 61941,
-                        "url": "https://oss.sonatype.org/service/local/repositories/snapshots/content/org/lwjgl/lwjgl-glfw/3.3.0-SNAPSHOT/lwjgl-glfw-3.3.0-20210325.222416-6-natives-windows-arm64.jar"
+                        "path": "org/lwjgl/lwjgl-glfw/3.3.0/lwjgl-glfw-3.3.0-natives-windows.jar",
+                        "sha1": "55f7adddaa1f575635f35fec166f0e80272bd85e",
+                        "size": 120840,
+                        "url": "https://oss.sonatype.org/service/local/repositories/releases/content/org/lwjgl/lwjgl-glfw/3.3.0/lwjgl-glfw-3.3.0-natives-windows-arm64.jar"
                     }
                 }
             },
-            "name": "org.lwjgl:lwjgl-glfw:3.3.0-SNAPSHOT",
+            "name": "org.lwjgl:lwjgl-glfw:3.3.0",
             "natives": {
                 "linux": "natives-linux",
                 "windows": "natives-windows"
@@ -1294,10 +1294,10 @@
         {
             "downloads": {
                 "artifact": {
-                    "path": "org/lwjgl/lwjgl-tinyfd/3.3.0-SNAPSHOT/lwjgl-tinyfd-3.3.0-SNAPSHOT.jar",
-                    "sha1": "a6b8fb51fac7b53101fcc1dce380766d76635b33",
-                    "size": 6758,
-                    "url": "https://oss.sonatype.org/service/local/repositories/snapshots/content/org/lwjgl/lwjgl-tinyfd/3.3.0-SNAPSHOT/lwjgl-tinyfd-3.3.0-20210325.222416-6.jar"
+                    "path": "org/lwjgl/lwjgl-tinyfd/3.3.0/lwjgl-tinyfd-3.3.0.jar",
+                    "sha1": "e3bf58d4830e2b35ee7e6f40b1eafd8637c290b8",
+                    "size": 6610,
+                    "url": "https://oss.sonatype.org/service/local/repositories/releases/content/org/lwjgl/lwjgl-tinyfd/3.3.0/lwjgl-tinyfd-3.3.0.jar"
                 },
                 "classifiers": {
                     "javadoc": {
@@ -1319,10 +1319,10 @@
                         "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-tinyfd/3.2.2/lwjgl-tinyfd-3.2.2-natives-macos.jar"
                     },
                     "natives-windows": {
-                        "path": "org/lwjgl/lwjgl-tinyfd/3.3.0-SNAPSHOT/lwjgl-tinyfd-3.3.0-SNAPSHOT-natives-windows.jar",
-                        "sha1": "07c93d2f5a1337322ee1eee49b1c850b50514683",
-                        "size": 98876,
-                        "url": "https://oss.sonatype.org/service/local/repositories/snapshots/content/org/lwjgl/lwjgl-tinyfd/3.3.0-SNAPSHOT/lwjgl-tinyfd-3.3.0-20210325.222416-6-natives-windows-arm64.jar"
+                        "path": "org/lwjgl/lwjgl-tinyfd/3.3.0/lwjgl-tinyfd-3.3.0-natives-windows.jar",
+                        "sha1": "925a96e3b08a1943f3f3910d8cd88dee87ea9fbd",
+                        "size": 106580,
+                        "url": "https://oss.sonatype.org/service/local/repositories/releases/content/org/lwjgl/lwjgl-tinyfd/3.3.0/lwjgl-tinyfd-3.3.0-natives-windows-arm64.jar"
                     },
                     "sources": {
                         "path": "org/lwjgl/lwjgl-tinyfd/3.2.2/lwjgl-tinyfd-3.2.2-sources.jar",
@@ -1332,7 +1332,7 @@
                     }
                 }
             },
-            "name": "org.lwjgl:lwjgl-tinyfd:3.3.0-SNAPSHOT",
+            "name": "org.lwjgl:lwjgl-tinyfd:3.3.0",
             "natives": {
                 "linux": "natives-linux",
                 "windows": "natives-windows"
@@ -1406,10 +1406,10 @@
         {
             "downloads": {
                 "artifact": {
-                    "path": "org/lwjgl/lwjgl-stb/3.3.0-SNAPSHOT/lwjgl-stb-3.3.0-SNAPSHOT.jar",
-                    "sha1": "e7a20f5ef01143f621131670c10cfee343968b82",
-                    "size": 111375,
-                    "url": "https://oss.sonatype.org/service/local/repositories/snapshots/content/org/lwjgl/lwjgl-stb/3.3.0-SNAPSHOT/lwjgl-stb-3.3.0-20210325.222416-6.jar"
+                    "path": "org/lwjgl/lwjgl-stb/3.3.0/lwjgl-stb-3.3.0.jar",
+                    "sha1": "69becce49e19671fccca33bfb273231055bd9fcf",
+                    "size": 109740,
+                    "url": "https://oss.sonatype.org/service/local/repositories/releases/content/org/lwjgl/lwjgl-stb/3.3.0/lwjgl-stb-3.3.0.jar"
                 },
                 "classifiers": {
                     "natives-linux": {
@@ -1425,14 +1425,14 @@
                         "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-stb/3.2.2/lwjgl-stb-3.2.2-natives-macos.jar"
                     },
                     "natives-windows": {
-                        "path": "org/lwjgl/lwjgl-stb/3.3.0-SNAPSHOT/lwjgl-stb-3.3.0-SNAPSHOT-natives-windows.jar",
-                        "sha1": "4c4faccb738a4347e076d5afe9c00454958ed161",
-                        "size": 199563,
-                        "url": "https://oss.sonatype.org/service/local/repositories/snapshots/content/org/lwjgl/lwjgl-stb/3.3.0-SNAPSHOT/lwjgl-stb-3.3.0-20210325.222416-6-natives-windows-arm64.jar"
+                        "path": "org/lwjgl/lwjgl-stb/3.3.0/lwjgl-stb-3.3.0-natives-windows.jar",
+                        "sha1": "25e92c7a10d7cc73c771796e278b31b419cc5cb2",
+                        "size": 211770,
+                        "url": "https://oss.sonatype.org/service/local/repositories/releases/content/org/lwjgl/lwjgl-stb/3.3.0/lwjgl-stb-3.3.0-natives-windows-arm64.jar"
                     }
                 }
             },
-            "name": "org.lwjgl:lwjgl-stb:3.3.0-SNAPSHOT",
+            "name": "org.lwjgl:lwjgl-stb:3.3.0",
             "natives": {
                 "linux": "natives-linux",
                 "windows": "natives-windows"

--- a/1.17.1-aarch64/1.17.1-aarch64.json
+++ b/1.17.1-aarch64/1.17.1-aarch64.json
@@ -472,13 +472,13 @@
         {
             "downloads": {
                 "artifact": {
-                    "path": "org/lwjgl/lwjgl/3.3.0-SNAPSHOT/lwjgl-3.3.0-SNAPSHOT.jar",
-                    "sha1": "58af756828308c0e6a2e481457de166a3d126c5a",
-                    "size": 567426,
-                    "url": "https://oss.sonatype.org/service/local/repositories/snapshots/content/org/lwjgl/lwjgl/3.3.0-SNAPSHOT/lwjgl-3.3.0-20210325.222416-6.jar"
+                    "path": "org/lwjgl/lwjgl/3.3.0/lwjgl-3.3.0.jar",
+                    "sha1": "77b0dc0b6a6c82fb47368e73d55e23fdcfcf49a1",
+                    "size": 555380,
+                    "url": "https://oss.sonatype.org/service/local/repositories/releases/content/org/lwjgl/lwjgl/3.3.0/lwjgl-3.3.0.jar"
                 }
             },
-            "name": "org.lwjgl:lwjgl:3.3.0-SNAPSHOT",
+            "name": "org.lwjgl:lwjgl:3.3.0",
             "rules": [
                 {
                     "action": "allow"
@@ -513,13 +513,13 @@
         {
             "downloads": {
                 "artifact": {
-                    "path": "org/lwjgl/lwjgl-jemalloc/3.3.0-SNAPSHOT/lwjgl-jemalloc-3.3.0-SNAPSHOT.jar",
-                    "sha1": "8b756cd284b4f7ba9706069725b90ad393a65599",
-                    "size": 36676,
-                    "url": "https://oss.sonatype.org/service/local/repositories/snapshots/content/org/lwjgl/lwjgl-jemalloc/3.3.0-SNAPSHOT/lwjgl-jemalloc-3.3.0-20210325.222416-6.jar"
+                    "path": "/org/lwjgl/lwjgl-jemalloc/3.3.0/lwjgl-jemalloc-3.3.0.jar",
+                    "sha1": "ce52faa3fd0c9ed7af45145e94b01eade5fd5daf",
+                    "size": 35740,
+                    "url": "https://oss.sonatype.org/service/local/repositories/releases/content/org/lwjgl/lwjgl-jemalloc/3.3.0/lwjgl-jemalloc-3.3.0.jar"
                 }
             },
-            "name": "org.lwjgl:lwjgl-jemalloc:3.3.0-SNAPSHOT",
+            "name": "org.lwjgl:lwjgl-jemalloc:3.3.0",
             "rules": [
                 {
                     "action": "allow"
@@ -554,13 +554,13 @@
         {
             "downloads": {
                 "artifact": {
-                    "path": "org/lwjgl/lwjgl-openal/3.3.0-SNAPSHOT/lwjgl-openal-3.3.0-SNAPSHOT.jar",
-                    "sha1": "6e8e9d7ae6d64c96f35618354401788a848d9748",
-                    "size": 88053,
-                    "url": "https://oss.sonatype.org/service/local/repositories/snapshots/content/org/lwjgl/lwjgl-openal/3.3.0-SNAPSHOT/lwjgl-openal-3.3.0-20210325.222416-6.jar"
+                    "path": "org/lwjgl/lwjgl-openal/3.3.0/lwjgl-openal-3.3.0.jar",
+                    "sha1": "902dd57b5a46e8a75ee843c2db61f80b4d130d48",
+                    "size": 86170,
+                    "url": "https://oss.sonatype.org/service/local/repositories/releases/content/org/lwjgl/lwjgl-openal/3.3.0/lwjgl-openal-3.3.0.jar"
                 }
             },
-            "name": "org.lwjgl:lwjgl-openal:3.3.0-SNAPSHOT",
+            "name": "org.lwjgl:lwjgl-openal:3.3.0",
             "rules": [
                 {
                     "action": "allow"
@@ -595,13 +595,13 @@
         {
             "downloads": {
                 "artifact": {
-                    "path": "org/lwjgl/lwjgl-opengl/3.3.0-SNAPSHOT/lwjgl-opengl-3.3.0-SNAPSHOT.jar",
-                    "sha1": "3aed63a7a8e158fd3e9d3e0a17358f38fe506a8c",
-                    "size": 916567,
-                    "url": "https://oss.sonatype.org/service/local/repositories/snapshots/content/org/lwjgl/lwjgl-opengl/3.3.0-SNAPSHOT/lwjgl-opengl-3.3.0-20210325.222416-6.jar"
+                    "path": "org/lwjgl/lwjgl-opengl/3.3.0/lwjgl-opengl-3.3.0.jar",
+                    "sha1": "a1f395f7758a3abd5aff75fc8a20368ac371631e",
+                    "size": 899820,
+                    "url": "https://oss.sonatype.org/service/local/repositories/releases/content/org/lwjgl/lwjgl-opengl/3.3.0/lwjgl-opengl-3.3.0.jar"
                 }
             },
-            "name": "org.lwjgl:lwjgl-opengl:3.3.0-SNAPSHOT",
+            "name": "org.lwjgl:lwjgl-opengl:3.3.0",
             "rules": [
                 {
                     "action": "allow"
@@ -636,13 +636,13 @@
         {
             "downloads": {
                 "artifact": {
-                    "path": "org/lwjgl/lwjgl-glfw/3.3.0-SNAPSHOT/lwjgl-glfw-3.3.0-SNAPSHOT.jar",
-                    "sha1": "0c41e6dff8c44fc7dcacda7c39c9297e7d100548",
-                    "size": 117915,
-                    "url": "https://oss.sonatype.org/service/local/repositories/snapshots/content/org/lwjgl/lwjgl-glfw/3.3.0-SNAPSHOT/lwjgl-glfw-3.3.0-20210325.222416-6.jar"
+                    "path": "org/lwjgl/lwjgl-glfw/3.3.0/lwjgl-glfw-3.3.0.jar",
+                    "sha1": "899e34f314525596f8fdb6476d3e56104da4601d",
+                    "size": 125600,
+                    "url": "https://oss.sonatype.org/service/local/repositories/releases/content/org/lwjgl/lwjgl-glfw/3.3.0/lwjgl-glfw-3.3.0.jar"
                 }
             },
-            "name": "org.lwjgl:lwjgl-glfw:3.3.0-SNAPSHOT",
+            "name": "org.lwjgl:lwjgl-glfw:3.3.0",
             "rules": [
                 {
                     "action": "allow"
@@ -677,13 +677,13 @@
         {
             "downloads": {
                 "artifact": {
-                    "path": "org/lwjgl/lwjgl-stb/3.3.0-SNAPSHOT/lwjgl-stb-3.3.0-SNAPSHOT.jar",
-                    "sha1": "e7a20f5ef01143f621131670c10cfee343968b82",
-                    "size": 111375,
-                    "url": "https://oss.sonatype.org/service/local/repositories/snapshots/content/org/lwjgl/lwjgl-stb/3.3.0-SNAPSHOT/lwjgl-stb-3.3.0-20210325.222416-6.jar"
+                    "path": "org/lwjgl/lwjgl-stb/3.3.0/lwjgl-stb-3.3.0.jar",
+                    "sha1": "69becce49e19671fccca33bfb273231055bd9fcf",
+                    "size": 109740,
+                    "url": "https://oss.sonatype.org/service/local/repositories/releases/content/org/lwjgl/lwjgl-stb/3.3.0/lwjgl-stb-3.3.0.jar"
                 }
             },
-            "name": "org.lwjgl:lwjgl-stb:3.3.0-SNAPSHOT",
+            "name": "org.lwjgl:lwjgl-stb:3.3.0",
             "rules": [
                 {
                     "action": "allow"
@@ -718,13 +718,13 @@
         {
             "downloads": {
                 "artifact": {
-                    "path": "org/lwjgl/lwjgl-tinyfd/3.3.0-SNAPSHOT/lwjgl-tinyfd-3.3.0-SNAPSHOT.jar",
-                    "sha1": "a6b8fb51fac7b53101fcc1dce380766d76635b33",
-                    "size": 6758,
-                    "url": "https://oss.sonatype.org/service/local/repositories/snapshots/content/org/lwjgl/lwjgl-tinyfd/3.3.0-SNAPSHOT/lwjgl-tinyfd-3.3.0-20210325.222416-6.jar"
+                    "path": "org/lwjgl/lwjgl-tinyfd/3.3.0/lwjgl-tinyfd-3.3.0.jar",
+                    "sha1": "e3bf58d4830e2b35ee7e6f40b1eafd8637c290b8",
+                    "size": 6610,
+                    "url": "https://oss.sonatype.org/service/local/repositories/releases/content/org/lwjgl/lwjgl-tinyfd/3.3.0/lwjgl-tinyfd-3.3.0.jar"
                 }
             },
-            "name": "org.lwjgl:lwjgl-tinyfd:3.3.0-SNAPSHOT",
+            "name": "org.lwjgl:lwjgl-tinyfd:3.3.0",
             "rules": [
                 {
                     "action": "allow"
@@ -794,10 +794,10 @@
         {
             "downloads": {
                 "artifact": {
-                    "path": "org/lwjgl/lwjgl/3.3.0-SNAPSHOT/lwjgl-3.3.0-SNAPSHOT.jar",
-                    "sha1": "58af756828308c0e6a2e481457de166a3d126c5a",
-                    "size": 567426,
-                    "url": "https://oss.sonatype.org/service/local/repositories/snapshots/content/org/lwjgl/lwjgl/3.3.0-SNAPSHOT/lwjgl-3.3.0-20210325.222416-6.jar"
+                    "path": "org/lwjgl/lwjgl/3.3.0/lwjgl-3.3.0.jar",
+                    "sha1": "77b0dc0b6a6c82fb47368e73d55e23fdcfcf49a1",
+                    "size": 555380,
+                    "url": "https://oss.sonatype.org/service/local/repositories/releases/content/org/lwjgl/lwjgl/3.3.0/lwjgl-3.3.0.jar"
                 },
                 "classifiers": {
                     "natives-linux": {
@@ -813,14 +813,14 @@
                         "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl/3.2.2/lwjgl-3.2.2-natives-macos.jar"
                     },
                     "natives-windows": {
-                        "path": "org/lwjgl/lwjgl/3.3.0-SNAPSHOT/lwjgl-3.3.0-SNAPSHOT-natives-windows.jar",
-                        "sha1": "c7a9cc3bc12bc06002e4a2efe0299c4236984409",
-                        "size": 123938,
-                        "url": "https://oss.sonatype.org/service/local/repositories/snapshots/content/org/lwjgl/lwjgl/3.3.0-SNAPSHOT/lwjgl-3.3.0-20210325.222416-6-natives-windows-arm64.jar"
+                        "path": "org/lwjgl/lwjgl/3.3.0/lwjgl-3.3.0-natives-windows.jar",
+                        "sha1": "a2a2ab21d619a4b08fdb52962761ccd822573908",
+                        "size": 124590,
+                        "url": "https://oss.sonatype.org/service/local/repositories/releases/content/org/lwjgl/lwjgl/3.3.0/lwjgl-3.3.0-natives-windows-arm64.jar"
                     }
                 }
             },
-            "name": "org.lwjgl:lwjgl:3.3.0-SNAPSHOT",
+            "name": "org.lwjgl:lwjgl:3.3.0",
             "natives": {
                 "linux": "natives-linux",
                 "windows": "natives-windows"
@@ -894,10 +894,10 @@
         {
             "downloads": {
                 "artifact": {
-                    "path": "org/lwjgl/lwjgl-jemalloc/3.3.0-SNAPSHOT/lwjgl-jemalloc-3.3.0-SNAPSHOT.jar",
-                    "sha1": "8b756cd284b4f7ba9706069725b90ad393a65599",
-                    "size": 36676,
-                    "url": "https://oss.sonatype.org/service/local/repositories/snapshots/content/org/lwjgl/lwjgl-jemalloc/3.3.0-SNAPSHOT/lwjgl-jemalloc-3.3.0-20210325.222416-6.jar"
+                    "path": "org/lwjgl/lwjgl-jemalloc/3.3.0/lwjgl-jemalloc-3.3.0.jar",
+                    "sha1": "ce52faa3fd0c9ed7af45145e94b01eade5fd5daf",
+                    "size": 35740,
+                    "url": "https://oss.sonatype.org/service/local/repositories/releases/content/org/lwjgl/lwjgl-jemalloc/3.3.0/lwjgl-jemalloc-3.3.0.jar"
                 },
                 "classifiers": {
                     "natives-linux": {
@@ -913,14 +913,14 @@
                         "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-jemalloc/3.2.2/lwjgl-jemalloc-3.2.2-natives-macos.jar"
                     },
                     "natives-windows": {
-                        "path": "org/lwjgl/lwjgl-jemalloc/3.3.0-SNAPSHOT/lwjgl-jemalloc-3.3.0-SNAPSHOT-natives-windows.jar",
-                        "sha1": "f8e04e4a3a2d887fe4052e27c8a2538abba370ae",
-                        "size": 107110,
-                        "url": "https://oss.sonatype.org/service/local/repositories/snapshots/content/org/lwjgl/lwjgl-jemalloc/3.3.0-SNAPSHOT/lwjgl-jemalloc-3.3.0-20210325.222416-6-natives-windows-arm64.jar"
+                        "path": "org/lwjgl/lwjgl-jemalloc/3.3.0/lwjgl-jemalloc-3.3.0-natives-windows.jar",
+                        "sha1": "fc4438bc0bd9535b3bb02aeae287a5cec3cf58dc",
+                        "size": 104470,
+                        "url": "https://oss.sonatype.org/service/local/repositories/releases/content/org/lwjgl/lwjgl-jemalloc/3.3.0/lwjgl-jemalloc-3.3.0-natives-windows-arm64.jar"
                     }
                 }
             },
-            "name": "org.lwjgl:lwjgl-jemalloc:3.3.0-SNAPSHOT",
+            "name": "org.lwjgl:lwjgl-jemalloc:3.3.0",
             "natives": {
                 "linux": "natives-linux",
                 "windows": "natives-windows"
@@ -994,10 +994,10 @@
         {
             "downloads": {
                 "artifact": {
-                    "path": "org/lwjgl/lwjgl-openal/3.3.0-SNAPSHOT/lwjgl-openal-3.3.0-SNAPSHOT.jar",
-                    "sha1": "6e8e9d7ae6d64c96f35618354401788a848d9748",
-                    "size": 88053,
-                    "url": "https://oss.sonatype.org/service/local/repositories/snapshots/content/org/lwjgl/lwjgl-openal/3.3.0-SNAPSHOT/lwjgl-openal-3.3.0-20210325.222416-6.jar"
+                    "path": "org/lwjgl/lwjgl-openal/3.3.0/lwjgl-openal-3.3.0.jar",
+                    "sha1": "902dd57b5a46e8a75ee843c2db61f80b4d130d48",
+                    "size": 56170,
+                    "url": "https://oss.sonatype.org/service/local/repositories/releases/content/org/lwjgl/lwjgl-openal/3.3.0/lwjgl-openal-3.3.0.jar"
                 },
                 "classifiers": {
                     "natives-linux": {
@@ -1013,14 +1013,14 @@
                         "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-openal/3.2.2/lwjgl-openal-3.2.2-natives-macos.jar"
                     },
                     "natives-windows": {
-                        "path": "org/lwjgl/lwjgl-openal/3.3.0-SNAPSHOT/lwjgl-openal-3.3.0-SNAPSHOT-natives-windows.jar",
-                        "sha1": "2b475d03d01adf84b75c914ffcf84a196214a091",
-                        "size": 503283,
-                        "url": "https://oss.sonatype.org/service/local/repositories/snapshots/content/org/lwjgl/lwjgl-openal/3.3.0-SNAPSHOT/lwjgl-openal-3.3.0-20210325.222416-6-natives-windows-arm64.jar"
+                        "path": "org/lwjgl/lwjgl-openal/3.3.0/lwjgl-openal-3.3.0-natives-windows.jar",
+                        "sha1": "c297c0db767a23af1ace227664ddd2887e900a43",
+                        "size": 493390,
+                        "url": "https://oss.sonatype.org/service/local/repositories/releases/content/org/lwjgl/lwjgl-openal/3.3.0/lwjgl-openal-3.3.0-natives-windows-arm64.jar"
                     }
                 }
             },
-            "name": "org.lwjgl:lwjgl-openal:3.3.0-SNAPSHOT",
+            "name": "org.lwjgl:lwjgl-openal:3.3.0",
             "natives": {
                 "linux": "natives-linux",
                 "windows": "natives-windows"
@@ -1094,10 +1094,10 @@
         {
             "downloads": {
                 "artifact": {
-                    "path": "org/lwjgl/lwjgl-opengl/3.3.0-SNAPSHOT/lwjgl-opengl-3.3.0-SNAPSHOT.jar",
-                    "sha1": "3aed63a7a8e158fd3e9d3e0a17358f38fe506a8c",
-                    "size": 916567,
-                    "url": "https://oss.sonatype.org/service/local/repositories/snapshots/content/org/lwjgl/lwjgl-opengl/3.3.0-SNAPSHOT/lwjgl-opengl-3.3.0-20210325.222416-6.jar"
+                    "path": "org/lwjgl/lwjgl-opengl/3.3.0/lwjgl-opengl-3.3.0.jar",
+                    "sha1": "a1f395f7758a3abd5aff75fc8a20368ac371631e",
+                    "size": 899820,
+                    "url": "https://oss.sonatype.org/service/local/repositories/releases/content/org/lwjgl/lwjgl-opengl/3.3.0/lwjgl-opengl-3.3.0.jar"
                 },
                 "classifiers": {
                     "natives-linux": {
@@ -1113,14 +1113,14 @@
                         "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-opengl/3.2.2/lwjgl-opengl-3.2.2-natives-macos.jar"
                     },
                     "natives-windows": {
-                        "path": "org/lwjgl/lwjgl-opengl/3.3.0-SNAPSHOT/lwjgl-opengl-3.3.0-SNAPSHOT-natives-windows.jar",
-                        "sha1": "69b52e6a28bfd10b13a358630e8c4662b9646c36",
-                        "size": 75496,
-                        "url": "https://oss.sonatype.org/service/local/repositories/snapshots/content/org/lwjgl/lwjgl-opengl/3.3.0-SNAPSHOT/lwjgl-opengl-3.3.0-20210325.222416-6-natives-windows-arm64.jar"
+                        "path": "org/lwjgl/lwjgl-opengl/3.3.0/lwjgl-opengl-3.3.0-natives-windows.jar",
+                        "sha1": "0b08e49c2ac976942b5fd6f146b790d0c0098c39",
+                        "size": 80280,
+                        "url": "https://oss.sonatype.org/service/local/repositories/releases/content/org/lwjgl/lwjgl-opengl/3.3.0/lwjgl-opengl-3.3.0-natives-windows-arm64.jar"
                     }
                 }
             },
-            "name": "org.lwjgl:lwjgl-opengl:3.3.0-SNAPSHOT",
+            "name": "org.lwjgl:lwjgl-opengl:3.3.0",
             "natives": {
                 "linux": "natives-linux",
                 "windows": "natives-windows"
@@ -1194,10 +1194,10 @@
         {
             "downloads": {
                 "artifact": {
-                    "path": "org/lwjgl/lwjgl-glfw/3.3.0-SNAPSHOT/lwjgl-glfw-3.3.0-SNAPSHOT.jar",
-                    "sha1": "0c41e6dff8c44fc7dcacda7c39c9297e7d100548",
-                    "size": 117915,
-                    "url": "https://oss.sonatype.org/service/local/repositories/snapshots/content/org/lwjgl/lwjgl-glfw/3.3.0-SNAPSHOT/lwjgl-glfw-3.3.0-20210325.222416-6.jar"
+                    "path": "org/lwjgl/lwjgl-glfw/3.3.0/lwjgl-glfw-3.3.0.jar",
+                    "sha1": "899e34f314525596f8fdb6476d3e56104da4601d",
+                    "size": 125600,
+                    "url": "https://oss.sonatype.org/service/local/repositories/releases/content/org/lwjgl/lwjgl-glfw/3.3.0/lwjgl-glfw-3.3.0.jar"
                 },
                 "classifiers": {
                     "natives-linux": {
@@ -1213,14 +1213,14 @@
                         "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-glfw/3.2.2/lwjgl-glfw-3.2.2-natives-macos.jar"
                     },
                     "natives-windows": {
-                        "path": "org/lwjgl/lwjgl-glfw/3.3.0-SNAPSHOT/lwjgl-glfw-3.3.0-SNAPSHOT-natives-windows.jar",
-                        "sha1": "9f3a847ca6d2f6f357fb8893a06cfd6de20ee74e",
-                        "size": 61941,
-                        "url": "https://oss.sonatype.org/service/local/repositories/snapshots/content/org/lwjgl/lwjgl-glfw/3.3.0-SNAPSHOT/lwjgl-glfw-3.3.0-20210325.222416-6-natives-windows-arm64.jar"
+                        "path": "org/lwjgl/lwjgl-glfw/3.3.0/lwjgl-glfw-3.3.0-natives-windows.jar",
+                        "sha1": "55f7adddaa1f575635f35fec166f0e80272bd85e",
+                        "size": 120840,
+                        "url": "https://oss.sonatype.org/service/local/repositories/releases/content/org/lwjgl/lwjgl-glfw/3.3.0/lwjgl-glfw-3.3.0-natives-windows-arm64.jar"
                     }
                 }
             },
-            "name": "org.lwjgl:lwjgl-glfw:3.3.0-SNAPSHOT",
+            "name": "org.lwjgl:lwjgl-glfw:3.3.0",
             "natives": {
                 "linux": "natives-linux",
                 "windows": "natives-windows"
@@ -1294,10 +1294,10 @@
         {
             "downloads": {
                 "artifact": {
-                    "path": "org/lwjgl/lwjgl-tinyfd/3.3.0-SNAPSHOT/lwjgl-tinyfd-3.3.0-SNAPSHOT.jar",
-                    "sha1": "a6b8fb51fac7b53101fcc1dce380766d76635b33",
-                    "size": 6758,
-                    "url": "https://oss.sonatype.org/service/local/repositories/snapshots/content/org/lwjgl/lwjgl-tinyfd/3.3.0-SNAPSHOT/lwjgl-tinyfd-3.3.0-20210325.222416-6.jar"
+                    "path": "org/lwjgl/lwjgl-tinyfd/3.3.0/lwjgl-tinyfd-3.3.0.jar",
+                    "sha1": "e3bf58d4830e2b35ee7e6f40b1eafd8637c290b8",
+                    "size": 6610,
+                    "url": "https://oss.sonatype.org/service/local/repositories/releases/content/org/lwjgl/lwjgl-tinyfd/3.3.0/lwjgl-tinyfd-3.3.0.jar"
                 },
                 "classifiers": {
                     "javadoc": {
@@ -1319,10 +1319,10 @@
                         "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-tinyfd/3.2.2/lwjgl-tinyfd-3.2.2-natives-macos.jar"
                     },
                     "natives-windows": {
-                        "path": "org/lwjgl/lwjgl-tinyfd/3.3.0-SNAPSHOT/lwjgl-tinyfd-3.3.0-SNAPSHOT-natives-windows.jar",
-                        "sha1": "07c93d2f5a1337322ee1eee49b1c850b50514683",
-                        "size": 98876,
-                        "url": "https://oss.sonatype.org/service/local/repositories/snapshots/content/org/lwjgl/lwjgl-tinyfd/3.3.0-SNAPSHOT/lwjgl-tinyfd-3.3.0-20210325.222416-6-natives-windows-arm64.jar"
+                        "path": "org/lwjgl/lwjgl-tinyfd/3.3.0/lwjgl-tinyfd-3.3.0-natives-windows.jar",
+                        "sha1": "925a96e3b08a1943f3f3910d8cd88dee87ea9fbd",
+                        "size": 106580,
+                        "url": "https://oss.sonatype.org/service/local/repositories/releases/content/org/lwjgl/lwjgl-tinyfd/3.3.0/lwjgl-tinyfd-3.3.0-natives-windows-arm64.jar"
                     },
                     "sources": {
                         "path": "org/lwjgl/lwjgl-tinyfd/3.2.2/lwjgl-tinyfd-3.2.2-sources.jar",
@@ -1332,7 +1332,7 @@
                     }
                 }
             },
-            "name": "org.lwjgl:lwjgl-tinyfd:3.3.0-SNAPSHOT",
+            "name": "org.lwjgl:lwjgl-tinyfd:3.3.0",
             "natives": {
                 "linux": "natives-linux",
                 "windows": "natives-windows"
@@ -1406,10 +1406,10 @@
         {
             "downloads": {
                 "artifact": {
-                    "path": "org/lwjgl/lwjgl-stb/3.3.0-SNAPSHOT/lwjgl-stb-3.3.0-SNAPSHOT.jar",
-                    "sha1": "e7a20f5ef01143f621131670c10cfee343968b82",
-                    "size": 111375,
-                    "url": "https://oss.sonatype.org/service/local/repositories/snapshots/content/org/lwjgl/lwjgl-stb/3.3.0-SNAPSHOT/lwjgl-stb-3.3.0-20210325.222416-6.jar"
+                    "path": "org/lwjgl/lwjgl-stb/3.3.0/lwjgl-stb-3.3.0.jar",
+                    "sha1": "69becce49e19671fccca33bfb273231055bd9fcf",
+                    "size": 109740,
+                    "url": "https://oss.sonatype.org/service/local/repositories/releases/content/org/lwjgl/lwjgl-stb/3.3.0/lwjgl-stb-3.3.0.jar"
                 },
                 "classifiers": {
                     "natives-linux": {
@@ -1425,14 +1425,14 @@
                         "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-stb/3.2.2/lwjgl-stb-3.2.2-natives-macos.jar"
                     },
                     "natives-windows": {
-                        "path": "org/lwjgl/lwjgl-stb/3.3.0-SNAPSHOT/lwjgl-stb-3.3.0-SNAPSHOT-natives-windows.jar",
-                        "sha1": "4c4faccb738a4347e076d5afe9c00454958ed161",
-                        "size": 199563,
-                        "url": "https://oss.sonatype.org/service/local/repositories/snapshots/content/org/lwjgl/lwjgl-stb/3.3.0-SNAPSHOT/lwjgl-stb-3.3.0-20210325.222416-6-natives-windows-arm64.jar"
+                        "path": "org/lwjgl/lwjgl-stb/3.3.0/lwjgl-stb-3.3.0-natives-windows.jar",
+                        "sha1": "25e92c7a10d7cc73c771796e278b31b419cc5cb2",
+                        "size": 211770,
+                        "url": "https://oss.sonatype.org/service/local/repositories/releases/content/org/lwjgl/lwjgl-stb/3.3.0/lwjgl-stb-3.3.0-natives-windows-arm64.jar"
                     }
                 }
             },
-            "name": "org.lwjgl:lwjgl-stb:3.3.0-SNAPSHOT",
+            "name": "org.lwjgl:lwjgl-stb:3.3.0",
             "natives": {
                 "linux": "natives-linux",
                 "windows": "natives-windows"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Running Minecraft 1.17 on Surface Pro X without any emulation
 1. Go to https://store.rg-adguard.net/ (or download [OpenCL™ and OpenGL® Compatibility Pack](https://aka.ms/clglcp-faq) if you insider's dev channel)
 2. Select "ProductId" and type 9nqpsl29bfff
 3. Download and install appx arm64 (eappx is encrypted, I don't know how to decrypt, so I used appx)
-4. Download https://github.com/microsoft/openjdk-aarch64/releases
+4. Download [OpenJDK 16 for AArch64](https://docs.microsoft.com/en-us/java/openjdk/download#openjdk-16)
 5. Download 1.17-aarch64 / 1.17.1-aarch64 and put it into your .minecraft\versions\ directory.
 6. Run 1.17-aarch64 / 1.17.1-aarch64 from Minecraft Launcher using downloaded java (`openjdk-aarch64`) without any JVM Arguments (you can keep `-Xmx2G`).
 


### PR DESCRIPTION
This PR:
- Switches lwjgl libraries to 3.3.0 release for 1.17.x (as snapshot links are dead ATM - backport of #6 )
- Updates README to specify use of OpenJDK 16 for MC 1.17.x - MC 1.17.x does not launch with OpenJDK 11/17 and launcher reports Java version mismatch when attempted.