### PR TITLE
Add 1.19-aarch64 profile

### DIFF
--- a/1.19-aarch64/1.19-aarch64.json
+++ b/1.19-aarch64/1.19-aarch64.json
@@ -621,6 +621,25 @@
         {
             "downloads": {
                 "artifact": {
+                    "path": "org/lwjgl/lwjgl/3.3.1/lwjgl-3.3.1-natives-windows-arm64.jar",
+                    "sha1": "0f46cadcf95675908fd3a550d63d9d709cb68998",
+                    "size": 130064,
+                    "url": "https://oss.sonatype.org/service/local/repositories/releases/content/org/lwjgl/lwjgl/3.3.1/lwjgl-3.3.1-natives-windows-arm64.jar"
+                }
+            },
+            "name": "org.lwjgl:lwjgl:3.3.1:natives-windows-arm64",
+            "rules": [
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "windows"
+                    }
+                }
+            ]
+        },
+        {
+            "downloads": {
+                "artifact": {
                     "path": "org/lwjgl/lwjgl/3.3.1/lwjgl-3.3.1-natives-linux.jar",
                     "sha1": "1de885aba434f934201b99f2f1afb142036ac189",
                     "size": 110704,
@@ -715,6 +734,25 @@
                 }
             },
             "name": "org.lwjgl:lwjgl-jemalloc:3.3.1:natives-windows-x86",
+            "rules": [
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "windows"
+                    }
+                }
+            ]
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "path": "org/lwjgl/lwjgl-jemalloc/3.3.1/lwjgl-jemalloc-3.3.1-natives-windows-arm64.jar",
+                    "sha1": "cae85c4edb219c88b6a0c26a87955ad98dc9519d",
+                    "size": 114250,
+                    "url": "https://oss.sonatype.org/service/local/repositories/releases/content/org/lwjgl/lwjgl-jemalloc/3.3.1/lwjgl-jemalloc-3.3.1-natives-windows-arm64.jar"
+                }
+            },
+            "name": "org.lwjgl:lwjgl-jemalloc:3.3.1:natives-windows-arm64",
             "rules": [
                 {
                     "action": "allow",
@@ -833,6 +871,25 @@
         {
             "downloads": {
                 "artifact": {
+                    "path": "org/lwjgl/lwjgl-openal/3.3.1/lwjgl-openal-3.3.1-natives-windows-arm64.jar",
+                    "sha1": "40d65f1a7368a2aa47336f9cb69f5a190cf9975a",
+                    "size": 505234,
+                    "url": "hhttps://oss.sonatype.org/service/local/repositories/releases/content/org/lwjgl/lwjgl-openal/3.3.1/lwjgl-openal-3.3.1-natives-windows-arm64.jar"
+                }
+            },
+            "name": "org.lwjgl:lwjgl-openal:3.3.1:natives-windows-arm64",
+            "rules": [
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "windows"
+                    }
+                }
+            ]
+        },
+        {
+            "downloads": {
+                "artifact": {
                     "path": "org/lwjgl/lwjgl-openal/3.3.1/lwjgl-openal-3.3.1-natives-linux.jar",
                     "sha1": "f906b6439f6daa66001182ea7727e3467a93681b",
                     "size": 476825,
@@ -927,6 +984,25 @@
                 }
             },
             "name": "org.lwjgl:lwjgl-opengl:3.3.1:natives-windows-x86",
+            "rules": [
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "windows"
+                    }
+                }
+            ]
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "path": "org/lwjgl/lwjgl-opengl/3.3.1/lwjgl-opengl-3.3.1-natives-windows-arm64.jar",
+                    "sha1": "527d78f1e9056aff3ed02ce93019c73c5e8f1721",
+                    "size": 82445,
+                    "url": "https://oss.sonatype.org/service/local/repositories/releases/content/org/lwjgl/lwjgl-opengl/3.3.1/lwjgl-opengl-3.3.1-natives-windows-arm64.jar"
+                }
+            },
+            "name": "org.lwjgl:lwjgl-opengl:3.3.1:natives-windows-arm64",
             "rules": [
                 {
                     "action": "allow",
@@ -1045,6 +1121,25 @@
         {
             "downloads": {
                 "artifact": {
+                    "path": "org/lwjgl/lwjgl-glfw/3.3.1/lwjgl-glfw-3.3.1-natives-windows-arm64.jar",
+                    "sha1": "beda65ee503443e60aa196d58ed31f8d001dc22a",
+                    "size": 123808,
+                    "url": "https://oss.sonatype.org/service/local/repositories/releases/content/org/lwjgl/lwjgl-glfw/3.3.1/lwjgl-glfw-3.3.1-natives-windows-arm64.jar"
+                }
+            },
+            "name": "org.lwjgl:lwjgl-glfw:3.3.1:natives-windows-arm64",
+            "rules": [
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "windows"
+                    }
+                }
+            ]
+        },
+        {
+            "downloads": {
+                "artifact": {
                     "path": "org/lwjgl/lwjgl-glfw/3.3.1/lwjgl-glfw-3.3.1-natives-linux.jar",
                     "sha1": "81716978214ecbda15050ca394b06ef61501a49e",
                     "size": 119817,
@@ -1151,6 +1246,25 @@
         {
             "downloads": {
                 "artifact": {
+                    "path": "org/lwjgl/lwjgl-stb/3.3.1/lwjgl-stb-3.3.1-natives-windows-arm64.jar",
+                    "sha1": "fde63cdd2605c00636721a6c8b961e41d1f6b247",
+                    "size": 216848,
+                    "url": "https://oss.sonatype.org/service/local/repositories/releases/content/org/lwjgl/lwjgl-stb/3.3.1/lwjgl-stb-3.3.1-natives-windows-arm64.jar"
+                }
+            },
+            "name": "org.lwjgl:lwjgl-stb:3.3.1:natives-windows-arm64",
+            "rules": [
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "windows"
+                    }
+                }
+            ]
+        },
+        {
+            "downloads": {
+                "artifact": {
                     "path": "org/lwjgl/lwjgl-stb/3.3.1/lwjgl-stb-3.3.1-natives-linux.jar",
                     "sha1": "3ee7aec8686e52867677110415566a5342a80230",
                     "size": 227237,
@@ -1245,6 +1359,25 @@
                 }
             },
             "name": "org.lwjgl:lwjgl-tinyfd:3.3.1:natives-windows-x86",
+            "rules": [
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "windows"
+                    }
+                }
+            ]
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "path": "org/lwjgl/lwjgl-tinyfd/3.3.1/lwjgl-tinyfd-3.3.1-natives-windows-arm64.jar",
+                    "sha1": "83a5e780df610829ff3a737822b4f931cffecd91",
+                    "size": 109139,
+                    "url": "https://oss.sonatype.org/service/local/repositories/releases/content/org/lwjgl/lwjgl-tinyfd/3.3.1/lwjgl-tinyfd-3.3.1-natives-windows-arm64.jar"
+                }
+            },
+            "name": "org.lwjgl:lwjgl-tinyfd:3.3.1:natives-windows-arm64",
             "rules": [
                 {
                     "action": "allow",

--- a/1.19-aarch64/1.19-aarch64.json
+++ b/1.19-aarch64/1.19-aarch64.json
@@ -874,7 +874,7 @@
                     "path": "org/lwjgl/lwjgl-openal/3.3.1/lwjgl-openal-3.3.1-natives-windows-arm64.jar",
                     "sha1": "40d65f1a7368a2aa47336f9cb69f5a190cf9975a",
                     "size": 505234,
-                    "url": "hhttps://oss.sonatype.org/service/local/repositories/releases/content/org/lwjgl/lwjgl-openal/3.3.1/lwjgl-openal-3.3.1-natives-windows-arm64.jar"
+                    "url": "https://oss.sonatype.org/service/local/repositories/releases/content/org/lwjgl/lwjgl-openal/3.3.1/lwjgl-openal-3.3.1-natives-windows-arm64.jar"
                 }
             },
             "name": "org.lwjgl:lwjgl-openal:3.3.1:natives-windows-arm64",

--- a/1.19-aarch64/1.19-aarch64.json
+++ b/1.19-aarch64/1.19-aarch64.json
@@ -140,7 +140,7 @@
             "url": "https://launcher.mojang.com/v1/objects/1c1cea17d5cd63d68356df2ef31e724dd09f8c26/server.txt"
         }
     },
-    "id": "1.19",
+    "id": "1.19-aarch64",
     "javaVersion": {
         "component": "java-runtime-gamma",
         "majorVersion": 17

--- a/1.19/1.19.json
+++ b/1.19/1.19.json
@@ -1,0 +1,1400 @@
+{
+    "arguments": {
+        "game": [
+            "--username",
+            "${auth_player_name}",
+            "--version",
+            "${version_name}",
+            "--gameDir",
+            "${game_directory}",
+            "--assetsDir",
+            "${assets_root}",
+            "--assetIndex",
+            "${assets_index_name}",
+            "--uuid",
+            "${auth_uuid}",
+            "--accessToken",
+            "${auth_access_token}",
+            "--clientId",
+            "${clientid}",
+            "--xuid",
+            "${auth_xuid}",
+            "--userType",
+            "${user_type}",
+            "--versionType",
+            "${version_type}",
+            {
+                "rules": [
+                    {
+                        "action": "allow",
+                        "features": {
+                            "is_demo_user": true
+                        }
+                    }
+                ],
+                "value": "--demo"
+            },
+            {
+                "rules": [
+                    {
+                        "action": "allow",
+                        "features": {
+                            "has_custom_resolution": true
+                        }
+                    }
+                ],
+                "value": [
+                    "--width",
+                    "${resolution_width}",
+                    "--height",
+                    "${resolution_height}"
+                ]
+            }
+        ],
+        "jvm": [
+            {
+                "rules": [
+                    {
+                        "action": "allow",
+                        "os": {
+                            "name": "osx"
+                        }
+                    }
+                ],
+                "value": [
+                    "-XstartOnFirstThread"
+                ]
+            },
+            {
+                "rules": [
+                    {
+                        "action": "allow",
+                        "os": {
+                            "name": "windows"
+                        }
+                    }
+                ],
+                "value": "-XX:HeapDumpPath=MojangTricksIntelDriversForPerformance_javaw.exe_minecraft.exe.heapdump"
+            },
+            {
+                "rules": [
+                    {
+                        "action": "allow",
+                        "os": {
+                            "name": "windows",
+                            "version": "^10\\."
+                        }
+                    }
+                ],
+                "value": [
+                    "-Dos.name=Windows 10",
+                    "-Dos.version=10.0"
+                ]
+            },
+            {
+                "rules": [
+                    {
+                        "action": "allow",
+                        "os": {
+                            "arch": "x86"
+                        }
+                    }
+                ],
+                "value": "-Xss1M"
+            },
+            "-Djava.library.path=${natives_directory}",
+            "-Dminecraft.launcher.brand=${launcher_name}",
+            "-Dminecraft.launcher.version=${launcher_version}",
+            "-cp",
+            "${classpath}"
+        ]
+    },
+    "assetIndex": {
+        "id": "1.19",
+        "sha1": "d45eb5e0c20e5d753468de3d68b05c45a946f49b",
+        "size": 385416,
+        "totalSize": 553754183,
+        "url": "https://piston-meta.mojang.com/v1/packages/d45eb5e0c20e5d753468de3d68b05c45a946f49b/1.19.json"
+    },
+    "assets": "1.19",
+    "complianceLevel": 1,
+    "downloads": {
+        "client": {
+            "sha1": "c0898ec7c6a5a2eaa317770203a1554260699994",
+            "size": 21462385,
+            "url": "https://launcher.mojang.com/v1/objects/c0898ec7c6a5a2eaa317770203a1554260699994/client.jar"
+        },
+        "client_mappings": {
+            "sha1": "150346d1c0b4acec0b4eb7f58b86e3ea1aa730f3",
+            "size": 7123832,
+            "url": "https://launcher.mojang.com/v1/objects/150346d1c0b4acec0b4eb7f58b86e3ea1aa730f3/client.txt"
+        },
+        "server": {
+            "sha1": "e00c4052dac1d59a1188b2aa9d5a87113aaf1122",
+            "size": 45538778,
+            "url": "https://launcher.mojang.com/v1/objects/e00c4052dac1d59a1188b2aa9d5a87113aaf1122/server.jar"
+        },
+        "server_mappings": {
+            "sha1": "1c1cea17d5cd63d68356df2ef31e724dd09f8c26",
+            "size": 5552032,
+            "url": "https://launcher.mojang.com/v1/objects/1c1cea17d5cd63d68356df2ef31e724dd09f8c26/server.txt"
+        }
+    },
+    "id": "1.19",
+    "javaVersion": {
+        "component": "java-runtime-gamma",
+        "majorVersion": 17
+    },
+    "libraries": [
+        {
+            "downloads": {
+                "artifact": {
+                    "path": "com/mojang/logging/1.0.0/logging-1.0.0.jar",
+                    "sha1": "f6ca3b2eee0b80b384e8ed93d368faecb82dfb9b",
+                    "size": 15343,
+                    "url": "https://libraries.minecraft.net/com/mojang/logging/1.0.0/logging-1.0.0.jar"
+                }
+            },
+            "name": "com.mojang:logging:1.0.0"
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "path": "com/mojang/blocklist/1.0.10/blocklist-1.0.10.jar",
+                    "sha1": "5c685c5ffa94c4cd39496c7184c1d122e515ecef",
+                    "size": 964,
+                    "url": "https://libraries.minecraft.net/com/mojang/blocklist/1.0.10/blocklist-1.0.10.jar"
+                }
+            },
+            "name": "com.mojang:blocklist:1.0.10"
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "path": "com/mojang/patchy/2.2.10/patchy-2.2.10.jar",
+                    "sha1": "da05971b07cbb379d002cf7eaec6a2048211fefc",
+                    "size": 4439,
+                    "url": "https://libraries.minecraft.net/com/mojang/patchy/2.2.10/patchy-2.2.10.jar"
+                }
+            },
+            "name": "com.mojang:patchy:2.2.10"
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "path": "com/github/oshi/oshi-core/5.8.5/oshi-core-5.8.5.jar",
+                    "sha1": "1d0ec654d820741327f5a9229d513732a4b7ce50",
+                    "size": 879623,
+                    "url": "https://libraries.minecraft.net/com/github/oshi/oshi-core/5.8.5/oshi-core-5.8.5.jar"
+                }
+            },
+            "name": "com.github.oshi:oshi-core:5.8.5"
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "path": "net/java/dev/jna/jna/5.10.0/jna-5.10.0.jar",
+                    "sha1": "7cf4c87dd802db50721db66947aa237d7ad09418",
+                    "size": 1756400,
+                    "url": "https://libraries.minecraft.net/net/java/dev/jna/jna/5.10.0/jna-5.10.0.jar"
+                }
+            },
+            "name": "net.java.dev.jna:jna:5.10.0"
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "path": "net/java/dev/jna/jna-platform/5.10.0/jna-platform-5.10.0.jar",
+                    "sha1": "fbed7d9669dba47714ad0d4f4454290a997aee69",
+                    "size": 1343495,
+                    "url": "https://libraries.minecraft.net/net/java/dev/jna/jna-platform/5.10.0/jna-platform-5.10.0.jar"
+                }
+            },
+            "name": "net.java.dev.jna:jna-platform:5.10.0"
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "path": "org/slf4j/slf4j-api/1.8.0-beta4/slf4j-api-1.8.0-beta4.jar",
+                    "sha1": "83b0359d847ee053d745be7ec0d8e9e8a44304b4",
+                    "size": 44213,
+                    "url": "https://libraries.minecraft.net/org/slf4j/slf4j-api/1.8.0-beta4/slf4j-api-1.8.0-beta4.jar"
+                }
+            },
+            "name": "org.slf4j:slf4j-api:1.8.0-beta4"
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "path": "org/apache/logging/log4j/log4j-slf4j18-impl/2.17.0/log4j-slf4j18-impl-2.17.0.jar",
+                    "sha1": "bd7f6c0b9224dd214afb4e684957e2349b529a8d",
+                    "size": 21244,
+                    "url": "https://libraries.minecraft.net/org/apache/logging/log4j/log4j-slf4j18-impl/2.17.0/log4j-slf4j18-impl-2.17.0.jar"
+                }
+            },
+            "name": "org.apache.logging.log4j:log4j-slf4j18-impl:2.17.0"
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "path": "com/ibm/icu/icu4j/70.1/icu4j-70.1.jar",
+                    "sha1": "dfa3a1fbc55bf5db8c6e79fc0935ac7ab1202950",
+                    "size": 13708936,
+                    "url": "https://libraries.minecraft.net/com/ibm/icu/icu4j/70.1/icu4j-70.1.jar"
+                }
+            },
+            "name": "com.ibm.icu:icu4j:70.1"
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "path": "com/mojang/javabridge/1.2.24/javabridge-1.2.24.jar",
+                    "sha1": "0c876796229b2ef5120f186eab5acc870699d3b9",
+                    "size": 6053,
+                    "url": "https://libraries.minecraft.net/com/mojang/javabridge/1.2.24/javabridge-1.2.24.jar"
+                }
+            },
+            "name": "com.mojang:javabridge:1.2.24"
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "path": "net/sf/jopt-simple/jopt-simple/5.0.4/jopt-simple-5.0.4.jar",
+                    "sha1": "4fdac2fbe92dfad86aa6e9301736f6b4342a3f5c",
+                    "size": 78146,
+                    "url": "https://libraries.minecraft.net/net/sf/jopt-simple/jopt-simple/5.0.4/jopt-simple-5.0.4.jar"
+                }
+            },
+            "name": "net.sf.jopt-simple:jopt-simple:5.0.4"
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "path": "io/netty/netty-common/4.1.77.Final/netty-common-4.1.77.Final.jar",
+                    "sha1": "ea0fc20f4e6178966b9d62017b7fcb83dfe0e713",
+                    "size": 653053,
+                    "url": "https://libraries.minecraft.net/io/netty/netty-common/4.1.77.Final/netty-common-4.1.77.Final.jar"
+                }
+            },
+            "name": "io.netty:netty-common:4.1.77.Final"
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "path": "io/netty/netty-buffer/4.1.77.Final/netty-buffer-4.1.77.Final.jar",
+                    "sha1": "d97571f99e5e739d86824d0df99f35d295276b5f",
+                    "size": 303738,
+                    "url": "https://libraries.minecraft.net/io/netty/netty-buffer/4.1.77.Final/netty-buffer-4.1.77.Final.jar"
+                }
+            },
+            "name": "io.netty:netty-buffer:4.1.77.Final"
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "path": "io/netty/netty-codec/4.1.77.Final/netty-codec-4.1.77.Final.jar",
+                    "sha1": "4efc5f59335301d6ba0d7cd31dd10651119b03c8",
+                    "size": 337017,
+                    "url": "https://libraries.minecraft.net/io/netty/netty-codec/4.1.77.Final/netty-codec-4.1.77.Final.jar"
+                }
+            },
+            "name": "io.netty:netty-codec:4.1.77.Final"
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "path": "io/netty/netty-handler/4.1.77.Final/netty-handler-4.1.77.Final.jar",
+                    "sha1": "47a81089de03635a27f509f3e4e13386ae1db275",
+                    "size": 528268,
+                    "url": "https://libraries.minecraft.net/io/netty/netty-handler/4.1.77.Final/netty-handler-4.1.77.Final.jar"
+                }
+            },
+            "name": "io.netty:netty-handler:4.1.77.Final"
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "path": "io/netty/netty-resolver/4.1.77.Final/netty-resolver-4.1.77.Final.jar",
+                    "sha1": "4a239dbf8d8bb5f98aa51462c35011c0516395fd",
+                    "size": 37776,
+                    "url": "https://libraries.minecraft.net/io/netty/netty-resolver/4.1.77.Final/netty-resolver-4.1.77.Final.jar"
+                }
+            },
+            "name": "io.netty:netty-resolver:4.1.77.Final"
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "path": "io/netty/netty-transport/4.1.77.Final/netty-transport-4.1.77.Final.jar",
+                    "sha1": "2a3373bbd20d520c821f210bd5ee886788512043",
+                    "size": 480832,
+                    "url": "https://libraries.minecraft.net/io/netty/netty-transport/4.1.77.Final/netty-transport-4.1.77.Final.jar"
+                }
+            },
+            "name": "io.netty:netty-transport:4.1.77.Final"
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "path": "io/netty/netty-transport-native-unix-common/4.1.77.Final/netty-transport-native-unix-common-4.1.77.Final.jar",
+                    "sha1": "c95d53486414b3270d08057957c5da8e0c37e4eb",
+                    "size": 43213,
+                    "url": "https://libraries.minecraft.net/io/netty/netty-transport-native-unix-common/4.1.77.Final/netty-transport-native-unix-common-4.1.77.Final.jar"
+                }
+            },
+            "name": "io.netty:netty-transport-native-unix-common:4.1.77.Final"
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "path": "io/netty/netty-transport-classes-epoll/4.1.77.Final/netty-transport-classes-epoll-4.1.77.Final.jar",
+                    "sha1": "dd70dbccbcf98382223a59044f3c08d8e9920cad",
+                    "size": 139612,
+                    "url": "https://libraries.minecraft.net/io/netty/netty-transport-classes-epoll/4.1.77.Final/netty-transport-classes-epoll-4.1.77.Final.jar"
+                }
+            },
+            "name": "io.netty:netty-transport-classes-epoll:4.1.77.Final"
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "path": "io/netty/netty-transport-native-epoll/4.1.77.Final/netty-transport-native-epoll-4.1.77.Final-linux-x86_64.jar",
+                    "sha1": "8d10e9e138dac52172dd83229bdc89197100c723",
+                    "size": 37633,
+                    "url": "https://libraries.minecraft.net/io/netty/netty-transport-native-epoll/4.1.77.Final/netty-transport-native-epoll-4.1.77.Final-linux-x86_64.jar"
+                }
+            },
+            "name": "io.netty:netty-transport-native-epoll:4.1.77.Final:linux-x86_64",
+            "rules": [
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "linux"
+                    }
+                }
+            ]
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "path": "io/netty/netty-transport-native-epoll/4.1.77.Final/netty-transport-native-epoll-4.1.77.Final-linux-aarch_64.jar",
+                    "sha1": "5f051599ced83e119ddeda891f471c0613721e5c",
+                    "size": 39226,
+                    "url": "https://libraries.minecraft.net/io/netty/netty-transport-native-epoll/4.1.77.Final/netty-transport-native-epoll-4.1.77.Final-linux-aarch_64.jar"
+                }
+            },
+            "name": "io.netty:netty-transport-native-epoll:4.1.77.Final:linux-aarch_64",
+            "rules": [
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "linux"
+                    }
+                }
+            ]
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "path": "com/google/guava/failureaccess/1.0.1/failureaccess-1.0.1.jar",
+                    "sha1": "1dcf1de382a0bf95a3d8b0849546c88bac1292c9",
+                    "size": 4617,
+                    "url": "https://libraries.minecraft.net/com/google/guava/failureaccess/1.0.1/failureaccess-1.0.1.jar"
+                }
+            },
+            "name": "com.google.guava:failureaccess:1.0.1"
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "path": "com/google/guava/guava/31.0.1-jre/guava-31.0.1-jre.jar",
+                    "sha1": "119ea2b2bc205b138974d351777b20f02b92704b",
+                    "size": 2974216,
+                    "url": "https://libraries.minecraft.net/com/google/guava/guava/31.0.1-jre/guava-31.0.1-jre.jar"
+                }
+            },
+            "name": "com.google.guava:guava:31.0.1-jre"
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "path": "org/apache/commons/commons-lang3/3.12.0/commons-lang3-3.12.0.jar",
+                    "sha1": "c6842c86792ff03b9f1d1fe2aab8dc23aa6c6f0e",
+                    "size": 587402,
+                    "url": "https://libraries.minecraft.net/org/apache/commons/commons-lang3/3.12.0/commons-lang3-3.12.0.jar"
+                }
+            },
+            "name": "org.apache.commons:commons-lang3:3.12.0"
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "path": "commons-io/commons-io/2.11.0/commons-io-2.11.0.jar",
+                    "sha1": "a2503f302b11ebde7ebc3df41daebe0e4eea3689",
+                    "size": 327135,
+                    "url": "https://libraries.minecraft.net/commons-io/commons-io/2.11.0/commons-io-2.11.0.jar"
+                }
+            },
+            "name": "commons-io:commons-io:2.11.0"
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "path": "commons-codec/commons-codec/1.15/commons-codec-1.15.jar",
+                    "sha1": "49d94806b6e3dc933dacbd8acb0fdbab8ebd1e5d",
+                    "size": 353793,
+                    "url": "https://libraries.minecraft.net/commons-codec/commons-codec/1.15/commons-codec-1.15.jar"
+                }
+            },
+            "name": "commons-codec:commons-codec:1.15"
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "path": "com/mojang/brigadier/1.0.18/brigadier-1.0.18.jar",
+                    "sha1": "c1ef1234282716483c92183f49bef47b1a89bfa9",
+                    "size": 77116,
+                    "url": "https://libraries.minecraft.net/com/mojang/brigadier/1.0.18/brigadier-1.0.18.jar"
+                }
+            },
+            "name": "com.mojang:brigadier:1.0.18"
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "path": "com/mojang/datafixerupper/5.0.28/datafixerupper-5.0.28.jar",
+                    "sha1": "e2157e236e529aff80a5fc3ccb506e56d46b130b",
+                    "size": 684966,
+                    "url": "https://libraries.minecraft.net/com/mojang/datafixerupper/5.0.28/datafixerupper-5.0.28.jar"
+                }
+            },
+            "name": "com.mojang:datafixerupper:5.0.28"
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "path": "com/google/code/gson/gson/2.8.9/gson-2.8.9.jar",
+                    "sha1": "8a432c1d6825781e21a02db2e2c33c5fde2833b9",
+                    "size": 258075,
+                    "url": "https://libraries.minecraft.net/com/google/code/gson/gson/2.8.9/gson-2.8.9.jar"
+                }
+            },
+            "name": "com.google.code.gson:gson:2.8.9"
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "path": "com/mojang/authlib/3.5.41/authlib-3.5.41.jar",
+                    "sha1": "9e05cb6a5f3504235a190ad11ea8981b2cbb901e",
+                    "size": 104806,
+                    "url": "https://libraries.minecraft.net/com/mojang/authlib/3.5.41/authlib-3.5.41.jar"
+                }
+            },
+            "name": "com.mojang:authlib:3.5.41"
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "path": "org/apache/commons/commons-compress/1.21/commons-compress-1.21.jar",
+                    "sha1": "4ec95b60d4e86b5c95a0e919cb172a0af98011ef",
+                    "size": 1018316,
+                    "url": "https://libraries.minecraft.net/org/apache/commons/commons-compress/1.21/commons-compress-1.21.jar"
+                }
+            },
+            "name": "org.apache.commons:commons-compress:1.21"
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "path": "org/apache/httpcomponents/httpclient/4.5.13/httpclient-4.5.13.jar",
+                    "sha1": "e5f6cae5ca7ecaac1ec2827a9e2d65ae2869cada",
+                    "size": 780321,
+                    "url": "https://libraries.minecraft.net/org/apache/httpcomponents/httpclient/4.5.13/httpclient-4.5.13.jar"
+                }
+            },
+            "name": "org.apache.httpcomponents:httpclient:4.5.13"
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "path": "commons-logging/commons-logging/1.2/commons-logging-1.2.jar",
+                    "sha1": "4bfc12adfe4842bf07b657f0369c4cb522955686",
+                    "size": 61829,
+                    "url": "https://libraries.minecraft.net/commons-logging/commons-logging/1.2/commons-logging-1.2.jar"
+                }
+            },
+            "name": "commons-logging:commons-logging:1.2"
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "path": "org/apache/httpcomponents/httpcore/4.4.14/httpcore-4.4.14.jar",
+                    "sha1": "9dd1a631c082d92ecd4bd8fd4cf55026c720a8c1",
+                    "size": 328436,
+                    "url": "https://libraries.minecraft.net/org/apache/httpcomponents/httpcore/4.4.14/httpcore-4.4.14.jar"
+                }
+            },
+            "name": "org.apache.httpcomponents:httpcore:4.4.14"
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "path": "it/unimi/dsi/fastutil/8.5.6/fastutil-8.5.6.jar",
+                    "sha1": "76f95700418a68fbc4ac050525261f05dc681ca1",
+                    "size": 23565248,
+                    "url": "https://libraries.minecraft.net/it/unimi/dsi/fastutil/8.5.6/fastutil-8.5.6.jar"
+                }
+            },
+            "name": "it.unimi.dsi:fastutil:8.5.6"
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "path": "org/apache/logging/log4j/log4j-api/2.17.0/log4j-api-2.17.0.jar",
+                    "sha1": "bbd791e9c8c9421e45337c4fe0a10851c086e36c",
+                    "size": 301776,
+                    "url": "https://libraries.minecraft.net/org/apache/logging/log4j/log4j-api/2.17.0/log4j-api-2.17.0.jar"
+                }
+            },
+            "name": "org.apache.logging.log4j:log4j-api:2.17.0"
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "path": "org/apache/logging/log4j/log4j-core/2.17.0/log4j-core-2.17.0.jar",
+                    "sha1": "fe6e7a32c1228884b9691a744f953a55d0dd8ead",
+                    "size": 1789339,
+                    "url": "https://libraries.minecraft.net/org/apache/logging/log4j/log4j-core/2.17.0/log4j-core-2.17.0.jar"
+                }
+            },
+            "name": "org.apache.logging.log4j:log4j-core:2.17.0"
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "path": "org/lwjgl/lwjgl/3.3.1/lwjgl-3.3.1.jar",
+                    "sha1": "ae58664f88e18a9bb2c77b063833ca7aaec484cb",
+                    "size": 724243,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl/3.3.1/lwjgl-3.3.1.jar"
+                }
+            },
+            "name": "org.lwjgl:lwjgl:3.3.1"
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "path": "org/lwjgl/lwjgl/3.3.1/lwjgl-3.3.1-natives-windows.jar",
+                    "sha1": "0036c37f16ab611b3aa11f3bcf80b1d509b4ce6b",
+                    "size": 159361,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl/3.3.1/lwjgl-3.3.1-natives-windows.jar"
+                }
+            },
+            "name": "org.lwjgl:lwjgl:3.3.1:natives-windows",
+            "rules": [
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "windows"
+                    }
+                }
+            ]
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "path": "org/lwjgl/lwjgl/3.3.1/lwjgl-3.3.1-natives-windows-x86.jar",
+                    "sha1": "3b14f4beae9dd39791ec9e12190a9380cd8a3ce6",
+                    "size": 134695,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl/3.3.1/lwjgl-3.3.1-natives-windows-x86.jar"
+                }
+            },
+            "name": "org.lwjgl:lwjgl:3.3.1:natives-windows-x86",
+            "rules": [
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "windows"
+                    }
+                }
+            ]
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "path": "org/lwjgl/lwjgl/3.3.1/lwjgl-3.3.1-natives-linux.jar",
+                    "sha1": "1de885aba434f934201b99f2f1afb142036ac189",
+                    "size": 110704,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl/3.3.1/lwjgl-3.3.1-natives-linux.jar"
+                }
+            },
+            "name": "org.lwjgl:lwjgl:3.3.1:natives-linux",
+            "rules": [
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "linux"
+                    }
+                }
+            ]
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "path": "org/lwjgl/lwjgl/3.3.1/lwjgl-3.3.1-natives-macos.jar",
+                    "sha1": "fc6bb723dec2cd031557dccb2a95f0ab80acb9db",
+                    "size": 55706,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl/3.3.1/lwjgl-3.3.1-natives-macos.jar"
+                }
+            },
+            "name": "org.lwjgl:lwjgl:3.3.1:natives-macos",
+            "rules": [
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "osx"
+                    }
+                }
+            ]
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "path": "org/lwjgl/lwjgl/3.3.1/lwjgl-3.3.1-natives-macos-arm64.jar",
+                    "sha1": "71d0d5e469c9c95351eb949064497e3391616ac9",
+                    "size": 42693,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl/3.3.1/lwjgl-3.3.1-natives-macos-arm64.jar"
+                }
+            },
+            "name": "org.lwjgl:lwjgl:3.3.1:natives-macos-arm64",
+            "rules": [
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "osx"
+                    }
+                }
+            ]
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "path": "org/lwjgl/lwjgl-jemalloc/3.3.1/lwjgl-jemalloc-3.3.1.jar",
+                    "sha1": "a817bcf213db49f710603677457567c37d53e103",
+                    "size": 36601,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-jemalloc/3.3.1/lwjgl-jemalloc-3.3.1.jar"
+                }
+            },
+            "name": "org.lwjgl:lwjgl-jemalloc:3.3.1"
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "path": "org/lwjgl/lwjgl-jemalloc/3.3.1/lwjgl-jemalloc-3.3.1-natives-windows.jar",
+                    "sha1": "948a89b76a16aa324b046ae9308891216ffce5f9",
+                    "size": 135585,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-jemalloc/3.3.1/lwjgl-jemalloc-3.3.1-natives-windows.jar"
+                }
+            },
+            "name": "org.lwjgl:lwjgl-jemalloc:3.3.1:natives-windows",
+            "rules": [
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "windows"
+                    }
+                }
+            ]
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "path": "org/lwjgl/lwjgl-jemalloc/3.3.1/lwjgl-jemalloc-3.3.1-natives-windows-x86.jar",
+                    "sha1": "fb476c8ec110e1c137ad3ce8a7f7bfe6b11c6324",
+                    "size": 110405,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-jemalloc/3.3.1/lwjgl-jemalloc-3.3.1-natives-windows-x86.jar"
+                }
+            },
+            "name": "org.lwjgl:lwjgl-jemalloc:3.3.1:natives-windows-x86",
+            "rules": [
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "windows"
+                    }
+                }
+            ]
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "path": "org/lwjgl/lwjgl-jemalloc/3.3.1/lwjgl-jemalloc-3.3.1-natives-linux.jar",
+                    "sha1": "33dbb017b6ed6b25f993ad9d56741a49e7937718",
+                    "size": 166524,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-jemalloc/3.3.1/lwjgl-jemalloc-3.3.1-natives-linux.jar"
+                }
+            },
+            "name": "org.lwjgl:lwjgl-jemalloc:3.3.1:natives-linux",
+            "rules": [
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "linux"
+                    }
+                }
+            ]
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "path": "org/lwjgl/lwjgl-jemalloc/3.3.1/lwjgl-jemalloc-3.3.1-natives-macos.jar",
+                    "sha1": "56424dc8db3cfb8e7b594aa6d59a4f4387b7f544",
+                    "size": 117480,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-jemalloc/3.3.1/lwjgl-jemalloc-3.3.1-natives-macos.jar"
+                }
+            },
+            "name": "org.lwjgl:lwjgl-jemalloc:3.3.1:natives-macos",
+            "rules": [
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "osx"
+                    }
+                }
+            ]
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "path": "org/lwjgl/lwjgl-jemalloc/3.3.1/lwjgl-jemalloc-3.3.1-natives-macos-arm64.jar",
+                    "sha1": "e577b87d8ad2ade361aaea2fcf226c660b15dee8",
+                    "size": 103475,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-jemalloc/3.3.1/lwjgl-jemalloc-3.3.1-natives-macos-arm64.jar"
+                }
+            },
+            "name": "org.lwjgl:lwjgl-jemalloc:3.3.1:natives-macos-arm64",
+            "rules": [
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "osx"
+                    }
+                }
+            ]
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "path": "org/lwjgl/lwjgl-openal/3.3.1/lwjgl-openal-3.3.1.jar",
+                    "sha1": "2623a6b8ae1dfcd880738656a9f0243d2e6840bd",
+                    "size": 88237,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-openal/3.3.1/lwjgl-openal-3.3.1.jar"
+                }
+            },
+            "name": "org.lwjgl:lwjgl-openal:3.3.1"
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "path": "org/lwjgl/lwjgl-openal/3.3.1/lwjgl-openal-3.3.1-natives-windows.jar",
+                    "sha1": "30a474d0e57193d7bc128849a3ab66bc9316fdb1",
+                    "size": 576872,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-openal/3.3.1/lwjgl-openal-3.3.1-natives-windows.jar"
+                }
+            },
+            "name": "org.lwjgl:lwjgl-openal:3.3.1:natives-windows",
+            "rules": [
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "windows"
+                    }
+                }
+            ]
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "path": "org/lwjgl/lwjgl-openal/3.3.1/lwjgl-openal-3.3.1-natives-windows-x86.jar",
+                    "sha1": "888349f7b1be6fbae58bf8edfb9ef12def04c4e3",
+                    "size": 520313,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-openal/3.3.1/lwjgl-openal-3.3.1-natives-windows-x86.jar"
+                }
+            },
+            "name": "org.lwjgl:lwjgl-openal:3.3.1:natives-windows-x86",
+            "rules": [
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "windows"
+                    }
+                }
+            ]
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "path": "org/lwjgl/lwjgl-openal/3.3.1/lwjgl-openal-3.3.1-natives-linux.jar",
+                    "sha1": "f906b6439f6daa66001182ea7727e3467a93681b",
+                    "size": 476825,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-openal/3.3.1/lwjgl-openal-3.3.1-natives-linux.jar"
+                }
+            },
+            "name": "org.lwjgl:lwjgl-openal:3.3.1:natives-linux",
+            "rules": [
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "linux"
+                    }
+                }
+            ]
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "path": "org/lwjgl/lwjgl-openal/3.3.1/lwjgl-openal-3.3.1-natives-macos.jar",
+                    "sha1": "3a57b8911835fb58b5e558d0ca0d28157e263d45",
+                    "size": 397196,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-openal/3.3.1/lwjgl-openal-3.3.1-natives-macos.jar"
+                }
+            },
+            "name": "org.lwjgl:lwjgl-openal:3.3.1:natives-macos",
+            "rules": [
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "osx"
+                    }
+                }
+            ]
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "path": "org/lwjgl/lwjgl-openal/3.3.1/lwjgl-openal-3.3.1-natives-macos-arm64.jar",
+                    "sha1": "23d55e7490b57495320f6c9e1936d78fd72c4ef8",
+                    "size": 346125,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-openal/3.3.1/lwjgl-openal-3.3.1-natives-macos-arm64.jar"
+                }
+            },
+            "name": "org.lwjgl:lwjgl-openal:3.3.1:natives-macos-arm64",
+            "rules": [
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "osx"
+                    }
+                }
+            ]
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "path": "org/lwjgl/lwjgl-opengl/3.3.1/lwjgl-opengl-3.3.1.jar",
+                    "sha1": "831a5533a21a5f4f81bbc51bb13e9899319b5411",
+                    "size": 921563,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-opengl/3.3.1/lwjgl-opengl-3.3.1.jar"
+                }
+            },
+            "name": "org.lwjgl:lwjgl-opengl:3.3.1"
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "path": "org/lwjgl/lwjgl-opengl/3.3.1/lwjgl-opengl-3.3.1-natives-windows.jar",
+                    "sha1": "c1807e9bd571402787d7e37e3029776ae2513bb8",
+                    "size": 100205,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-opengl/3.3.1/lwjgl-opengl-3.3.1-natives-windows.jar"
+                }
+            },
+            "name": "org.lwjgl:lwjgl-opengl:3.3.1:natives-windows",
+            "rules": [
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "windows"
+                    }
+                }
+            ]
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "path": "org/lwjgl/lwjgl-opengl/3.3.1/lwjgl-opengl-3.3.1-natives-windows-x86.jar",
+                    "sha1": "deef3eb9b178ff2ff3ce893cc72ae741c3a17974",
+                    "size": 87463,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-opengl/3.3.1/lwjgl-opengl-3.3.1-natives-windows-x86.jar"
+                }
+            },
+            "name": "org.lwjgl:lwjgl-opengl:3.3.1:natives-windows-x86",
+            "rules": [
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "windows"
+                    }
+                }
+            ]
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "path": "org/lwjgl/lwjgl-opengl/3.3.1/lwjgl-opengl-3.3.1-natives-linux.jar",
+                    "sha1": "ab9ab6fde3743e3550fa5d46d785ecb45b047d99",
+                    "size": 79125,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-opengl/3.3.1/lwjgl-opengl-3.3.1-natives-linux.jar"
+                }
+            },
+            "name": "org.lwjgl:lwjgl-opengl:3.3.1:natives-linux",
+            "rules": [
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "linux"
+                    }
+                }
+            ]
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "path": "org/lwjgl/lwjgl-opengl/3.3.1/lwjgl-opengl-3.3.1-natives-macos.jar",
+                    "sha1": "a0d12697ea019a7362eff26475b0531340e876a6",
+                    "size": 40709,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-opengl/3.3.1/lwjgl-opengl-3.3.1-natives-macos.jar"
+                }
+            },
+            "name": "org.lwjgl:lwjgl-opengl:3.3.1:natives-macos",
+            "rules": [
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "osx"
+                    }
+                }
+            ]
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "path": "org/lwjgl/lwjgl-opengl/3.3.1/lwjgl-opengl-3.3.1-natives-macos-arm64.jar",
+                    "sha1": "eafe34b871d966292e8db0f1f3d6b8b110d4e91d",
+                    "size": 41665,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-opengl/3.3.1/lwjgl-opengl-3.3.1-natives-macos-arm64.jar"
+                }
+            },
+            "name": "org.lwjgl:lwjgl-opengl:3.3.1:natives-macos-arm64",
+            "rules": [
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "osx"
+                    }
+                }
+            ]
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "path": "org/lwjgl/lwjgl-glfw/3.3.1/lwjgl-glfw-3.3.1.jar",
+                    "sha1": "cbac1b8d30cb4795149c1ef540f912671a8616d0",
+                    "size": 128801,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-glfw/3.3.1/lwjgl-glfw-3.3.1.jar"
+                }
+            },
+            "name": "org.lwjgl:lwjgl-glfw:3.3.1"
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "path": "org/lwjgl/lwjgl-glfw/3.3.1/lwjgl-glfw-3.3.1-natives-windows.jar",
+                    "sha1": "ed892f945cf7e79c8756796f32d00fa4ceaf573b",
+                    "size": 145512,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-glfw/3.3.1/lwjgl-glfw-3.3.1-natives-windows.jar"
+                }
+            },
+            "name": "org.lwjgl:lwjgl-glfw:3.3.1:natives-windows",
+            "rules": [
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "windows"
+                    }
+                }
+            ]
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "path": "org/lwjgl/lwjgl-glfw/3.3.1/lwjgl-glfw-3.3.1-natives-windows-x86.jar",
+                    "sha1": "b997e3391d6ce8f05487e7335d95c606043884a1",
+                    "size": 139251,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-glfw/3.3.1/lwjgl-glfw-3.3.1-natives-windows-x86.jar"
+                }
+            },
+            "name": "org.lwjgl:lwjgl-glfw:3.3.1:natives-windows-x86",
+            "rules": [
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "windows"
+                    }
+                }
+            ]
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "path": "org/lwjgl/lwjgl-glfw/3.3.1/lwjgl-glfw-3.3.1-natives-linux.jar",
+                    "sha1": "81716978214ecbda15050ca394b06ef61501a49e",
+                    "size": 119817,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-glfw/3.3.1/lwjgl-glfw-3.3.1-natives-linux.jar"
+                }
+            },
+            "name": "org.lwjgl:lwjgl-glfw:3.3.1:natives-linux",
+            "rules": [
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "linux"
+                    }
+                }
+            ]
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "path": "org/lwjgl/lwjgl-glfw/3.3.1/lwjgl-glfw-3.3.1-natives-macos.jar",
+                    "sha1": "9ec4ce1fc8c85fdef03ef4ff2aace6f5775fb280",
+                    "size": 131655,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-glfw/3.3.1/lwjgl-glfw-3.3.1-natives-macos.jar"
+                }
+            },
+            "name": "org.lwjgl:lwjgl-glfw:3.3.1:natives-macos",
+            "rules": [
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "osx"
+                    }
+                }
+            ]
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "path": "org/lwjgl/lwjgl-glfw/3.3.1/lwjgl-glfw-3.3.1-natives-macos-arm64.jar",
+                    "sha1": "cac0d3f712a3da7641fa174735a5f315de7ffe0a",
+                    "size": 129077,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-glfw/3.3.1/lwjgl-glfw-3.3.1-natives-macos-arm64.jar"
+                }
+            },
+            "name": "org.lwjgl:lwjgl-glfw:3.3.1:natives-macos-arm64",
+            "rules": [
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "osx"
+                    }
+                }
+            ]
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "path": "org/lwjgl/lwjgl-stb/3.3.1/lwjgl-stb-3.3.1.jar",
+                    "sha1": "b119297cf8ed01f247abe8685857f8e7fcf5980f",
+                    "size": 112380,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-stb/3.3.1/lwjgl-stb-3.3.1.jar"
+                }
+            },
+            "name": "org.lwjgl:lwjgl-stb:3.3.1"
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "path": "org/lwjgl/lwjgl-stb/3.3.1/lwjgl-stb-3.3.1-natives-windows.jar",
+                    "sha1": "86315914ac119efdb02dc9e8e978ade84f1702af",
+                    "size": 256301,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-stb/3.3.1/lwjgl-stb-3.3.1-natives-windows.jar"
+                }
+            },
+            "name": "org.lwjgl:lwjgl-stb:3.3.1:natives-windows",
+            "rules": [
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "windows"
+                    }
+                }
+            ]
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "path": "org/lwjgl/lwjgl-stb/3.3.1/lwjgl-stb-3.3.1-natives-windows-x86.jar",
+                    "sha1": "a8d41f419eecb430b7c91ea2ce2c5c451cae2091",
+                    "size": 225147,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-stb/3.3.1/lwjgl-stb-3.3.1-natives-windows-x86.jar"
+                }
+            },
+            "name": "org.lwjgl:lwjgl-stb:3.3.1:natives-windows-x86",
+            "rules": [
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "windows"
+                    }
+                }
+            ]
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "path": "org/lwjgl/lwjgl-stb/3.3.1/lwjgl-stb-3.3.1-natives-linux.jar",
+                    "sha1": "3ee7aec8686e52867677110415566a5342a80230",
+                    "size": 227237,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-stb/3.3.1/lwjgl-stb-3.3.1-natives-linux.jar"
+                }
+            },
+            "name": "org.lwjgl:lwjgl-stb:3.3.1:natives-linux",
+            "rules": [
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "linux"
+                    }
+                }
+            ]
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "path": "org/lwjgl/lwjgl-stb/3.3.1/lwjgl-stb-3.3.1-natives-macos.jar",
+                    "sha1": "def8879b8d38a47a4cc1d48b1f9a7b772e51258e",
+                    "size": 203582,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-stb/3.3.1/lwjgl-stb-3.3.1-natives-macos.jar"
+                }
+            },
+            "name": "org.lwjgl:lwjgl-stb:3.3.1:natives-macos",
+            "rules": [
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "osx"
+                    }
+                }
+            ]
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "path": "org/lwjgl/lwjgl-stb/3.3.1/lwjgl-stb-3.3.1-natives-macos-arm64.jar",
+                    "sha1": "fcf073ed911752abdca5f0b00a53cfdf17ff8e8b",
+                    "size": 178408,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-stb/3.3.1/lwjgl-stb-3.3.1-natives-macos-arm64.jar"
+                }
+            },
+            "name": "org.lwjgl:lwjgl-stb:3.3.1:natives-macos-arm64",
+            "rules": [
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "osx"
+                    }
+                }
+            ]
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "path": "org/lwjgl/lwjgl-tinyfd/3.3.1/lwjgl-tinyfd-3.3.1.jar",
+                    "sha1": "0ff1914111ef2e3e0110ef2dabc8d8cdaad82347",
+                    "size": 6767,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-tinyfd/3.3.1/lwjgl-tinyfd-3.3.1.jar"
+                }
+            },
+            "name": "org.lwjgl:lwjgl-tinyfd:3.3.1"
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "path": "org/lwjgl/lwjgl-tinyfd/3.3.1/lwjgl-tinyfd-3.3.1-natives-windows.jar",
+                    "sha1": "a5d830475ec0958d9fdba1559efa99aef211e6ff",
+                    "size": 127930,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-tinyfd/3.3.1/lwjgl-tinyfd-3.3.1-natives-windows.jar"
+                }
+            },
+            "name": "org.lwjgl:lwjgl-tinyfd:3.3.1:natives-windows",
+            "rules": [
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "windows"
+                    }
+                }
+            ]
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "path": "org/lwjgl/lwjgl-tinyfd/3.3.1/lwjgl-tinyfd-3.3.1-natives-windows-x86.jar",
+                    "sha1": "842eedd876fae354abc308c98a263f6bbc9e8a4d",
+                    "size": 110042,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-tinyfd/3.3.1/lwjgl-tinyfd-3.3.1-natives-windows-x86.jar"
+                }
+            },
+            "name": "org.lwjgl:lwjgl-tinyfd:3.3.1:natives-windows-x86",
+            "rules": [
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "windows"
+                    }
+                }
+            ]
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "path": "org/lwjgl/lwjgl-tinyfd/3.3.1/lwjgl-tinyfd-3.3.1-natives-linux.jar",
+                    "sha1": "a35110b9471bea8cde826ab297550ee8c22f5035",
+                    "size": 45389,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-tinyfd/3.3.1/lwjgl-tinyfd-3.3.1-natives-linux.jar"
+                }
+            },
+            "name": "org.lwjgl:lwjgl-tinyfd:3.3.1:natives-linux",
+            "rules": [
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "linux"
+                    }
+                }
+            ]
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "path": "org/lwjgl/lwjgl-tinyfd/3.3.1/lwjgl-tinyfd-3.3.1-natives-macos.jar",
+                    "sha1": "78641a0fa5e9afa714adfdd152c357930c97a1ce",
+                    "size": 44821,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-tinyfd/3.3.1/lwjgl-tinyfd-3.3.1-natives-macos.jar"
+                }
+            },
+            "name": "org.lwjgl:lwjgl-tinyfd:3.3.1:natives-macos",
+            "rules": [
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "osx"
+                    }
+                }
+            ]
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "path": "org/lwjgl/lwjgl-tinyfd/3.3.1/lwjgl-tinyfd-3.3.1-natives-macos-arm64.jar",
+                    "sha1": "972ecc17bad3571e81162153077b4d47b7b9eaa9",
+                    "size": 41380,
+                    "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-tinyfd/3.3.1/lwjgl-tinyfd-3.3.1-natives-macos-arm64.jar"
+                }
+            },
+            "name": "org.lwjgl:lwjgl-tinyfd:3.3.1:natives-macos-arm64",
+            "rules": [
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "osx"
+                    }
+                }
+            ]
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "path": "com/mojang/text2speech/1.13.9/text2speech-1.13.9.jar",
+                    "sha1": "5f4e3a6ef86cb021f7ca87ca192cddb50c26eb59",
+                    "size": 12123,
+                    "url": "https://libraries.minecraft.net/com/mojang/text2speech/1.13.9/text2speech-1.13.9.jar"
+                }
+            },
+            "name": "com.mojang:text2speech:1.13.9"
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "path": "com/mojang/text2speech/1.13.9/text2speech-1.13.9-natives-windows.jar",
+                    "sha1": "7a90898b29e5c72f90ba6ebe86fa78a6afd7d3eb",
+                    "size": 81379,
+                    "url": "https://libraries.minecraft.net/com/mojang/text2speech/1.13.9/text2speech-1.13.9-natives-windows.jar"
+                }
+            },
+            "name": "com.mojang:text2speech:1.13.9:natives-windows",
+            "rules": [
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "windows"
+                    }
+                }
+            ]
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "path": "com/mojang/text2speech/1.13.9/text2speech-1.13.9-natives-linux.jar",
+                    "sha1": "6c63ecb3b6408dcfdde6440c9ee62c060542af33",
+                    "size": 7833,
+                    "url": "https://libraries.minecraft.net/com/mojang/text2speech/1.13.9/text2speech-1.13.9-natives-linux.jar"
+                }
+            },
+            "name": "com.mojang:text2speech:1.13.9:natives-linux",
+            "rules": [
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "linux"
+                    }
+                }
+            ]
+        },
+        {
+            "downloads": {
+                "artifact": {
+                    "path": "ca/weblite/java-objc-bridge/1.1/java-objc-bridge-1.1.jar",
+                    "sha1": "1227f9e0666314f9de41477e3ec277e542ed7f7b",
+                    "size": 1330045,
+                    "url": "https://libraries.minecraft.net/ca/weblite/java-objc-bridge/1.1/java-objc-bridge-1.1.jar"
+                }
+            },
+            "name": "ca.weblite:java-objc-bridge:1.1",
+            "rules": [
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "osx"
+                    }
+                }
+            ]
+        }
+    ],
+    "logging": {
+        "client": {
+            "argument": "-Dlog4j.configurationFile=${path}",
+            "file": {
+                "id": "client-1.12.xml",
+                "sha1": "bd65e7d2e3c237be76cfbef4c2405033d7f91521",
+                "size": 888,
+                "url": "https://launcher.mojang.com/v1/objects/bd65e7d2e3c237be76cfbef4c2405033d7f91521/client-1.12.xml"
+            },
+            "type": "log4j2-xml"
+        }
+    },
+    "mainClass": "net.minecraft.client.main.Main",
+    "minimumLauncherVersion": 21,
+    "releaseTime": "2022-06-07T09:42:18+00:00",
+    "time": "2022-06-07T09:42:18+00:00",
+    "type": "release"
+}

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Running Minecraft 1.17 (or higher) on Surface Pro X without any emulation
 3. Download and install appx arm64 (eappx is encrypted, I don't know how to decrypt, so I used appx)
 4. Download [OpenJDK for AArch64](https://docs.microsoft.com/en-us/java/openjdk/download)
    - For 1.17 / 1.17.1, use [OpenJDK 16 for AArch64](https://docs.microsoft.com/en-us/java/openjdk/download#openjdk-16)
-   - For 1.18.1 / 1.18.2, use [OpenJDK 17 for AArch64](https://docs.microsoft.com/en-us/java/openjdk/download#openjdk-17)
+   - For 1.18.x / 1.19, use [OpenJDK 17 for AArch64](https://docs.microsoft.com/en-us/java/openjdk/download#openjdk-17)
 5. Download Minecraft aarch64 version profile from this repo and put it into your .minecraft\versions\ directory.
 6. Run aarch64 version of Minecraft from Minecraft Launcher using downloaded java (`openjdk-aarch64`) without any JVM Arguments (you can keep `-Xmx2G`).
 


### PR DESCRIPTION
Closes #13

This PR adds Windows on ARM-compatible profile for MC 1.19. Apparantly Mojang updated lwjgl version for default profile to 3.3.1, reducing the modding work from our end. :)

Like all previous profiles that I have created PR for, this modded profile is tested and confirmed running on my SPX (SQ1).