### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ Running Minecraft 1.17 (or higher) on Surface Pro X without any emulation
 4. Download [OpenJDK for AArch64](https://docs.microsoft.com/en-us/java/openjdk/download)
    - For 1.17 / 1.17.1, use [OpenJDK 16 for AArch64](https://docs.microsoft.com/en-us/java/openjdk/download#openjdk-16)
    - For 1.18.x / 1.19, use [OpenJDK 17 for AArch64](https://docs.microsoft.com/en-us/java/openjdk/download#openjdk-17)
-5. Download Minecraft aarch64 version profile from this repo and put it into your .minecraft\versions\ directory.
+5. Download Minecraft aarch64 version profile from this repo and put it into your `.minecraft\versions\` directory.
+   - This step is no longer necessary if you are playing 1.19+.
 6. Run aarch64 version of Minecraft from Minecraft Launcher using downloaded java (`openjdk-aarch64`) without any JVM Arguments (you can keep `-Xmx2G`).
 
 It's possible to run any version of Minecraft Java Edition starting from 21w10a / 1.17 (the game now runs using OpenGL 3.2 core profile)


### PR DESCRIPTION
TL;DR: No more need to tinker version profiles. :smile:

I just checked on the vanilla profiles for 1.19.x and 1.20.x and turns out... Mojang silently (or at least I could not find any announcment from them mentioning this) included arm64 artifacts for lwjgl since 1.19. This implies that we no longer need to tinker the version profiles to make MC run on Windows on ARM natively (hurray!).

Thus, this PR documents this (undocumented) upstream change in this repo's README.